### PR TITLE
fix: trigger crash/contact when train reaches dead-end track

### DIFF
--- a/src/main/java/letrain/audio/AudioController.java
+++ b/src/main/java/letrain/audio/AudioController.java
@@ -223,8 +223,13 @@ public class AudioController {
             synth.update();
 
             // Sync Throttle (Engine Sound)
-            int targetNotch = Math.min(loco.getTargetSpeed(), 10);
-            synth.setThrottle(targetNotch);
+            if (loco.isForceIdleSound()) {
+                synth.forceIdle();
+                loco.setForceIdleSound(false);
+            } else {
+                int targetNotch = Math.min(loco.getTargetSpeed(), 10);
+                synth.setThrottle(targetNotch);
+            }
 
             // Sync Motion (Rolling Sound)
             int currentSpeed = loco.getSpeed();

--- a/src/main/java/letrain/audio/synth/TrainSynthesizer.java
+++ b/src/main/java/letrain/audio/synth/TrainSynthesizer.java
@@ -602,9 +602,11 @@ public class TrainSynthesizer implements AudioSource {
 
         currentNotchIndex = 0;
         targetNotchIndex = 0;
+        locoEngine.setLoopMode(GrainEngine.LoopMode.PING_PONG);
+        locoEngine.setTurnProbability(0.15f);
         applyLoopForNotch(0);
         locoEngine.setSpeed(notches[0].cruiseSpeed);
-        coachEngine.setVolume(0.0f);
+        engineStarting = false;
         state = State.IDLE;
         setBraking(false);
         notifyNotch(0);

--- a/src/main/java/letrain/audio/synth/TrainSynthesizer.java
+++ b/src/main/java/letrain/audio/synth/TrainSynthesizer.java
@@ -592,6 +592,24 @@ public class TrainSynthesizer implements AudioSource {
      * Si ya hay transición en curso, actualiza el target y deja que el hilo
      * la detecte en el siguiente paso.
      */
+    /**
+     * Fuerza una transición inmediata a ralentí (notch 0), saltándose cualquier
+     * rampa en curso. Se usa cuando un tren choca o llega a un fin de vía.
+     */
+    public synchronized void forceIdle() {
+        if (state == State.OFF || state == State.STOPPING)
+            return;
+
+        currentNotchIndex = 0;
+        targetNotchIndex = 0;
+        applyLoopForNotch(0);
+        locoEngine.setSpeed(notches[0].cruiseSpeed);
+        coachEngine.setVolume(0.0f);
+        state = State.IDLE;
+        setBraking(false);
+        notifyNotch(0);
+    }
+
     public synchronized void setThrottle(int index) {
         if (state == State.STOPPING || state == State.STARTING)
             return;

--- a/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
@@ -239,6 +239,16 @@ public class Locomotive extends Linker implements Tractor {
 
     private volatile int acousticSpeedSignal = -1;
 
+    private boolean forceIdleSound = false;
+
+    public void setForceIdleSound(boolean force) {
+        this.forceIdleSound = force;
+    }
+
+    public boolean isForceIdleSound() {
+        return forceIdleSound;
+    }
+
     public void setAcousticSpeedSignal(int notch) {
         this.acousticSpeedSignal = notch;
     }

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -785,6 +785,8 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                         if (l instanceof Locomotive) {
                             ((Locomotive) l).setCurrentSpeed(0);
                             ((Locomotive) l).setTargetSpeed(0);
+                            ((Locomotive) l).setAcousticSpeedSignal(-1);
+                            ((Locomotive) l).setEngineTransitioning(false);
                         }
                         l.destroy();
                     });
@@ -796,6 +798,10 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                 getTractors().forEach(t -> {
                     t.setCurrentSpeed(0);
                     t.setTargetSpeed(0);
+                    if (t instanceof Locomotive) {
+                        ((Locomotive) t).setAcousticSpeedSignal(-1);
+                        ((Locomotive) t).setEngineTransitioning(false);
+                    }
                 });
                 this.setStalled(true);
             }

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -766,6 +766,9 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                     getTractors().forEach(t -> {
                         t.setCurrentSpeed(0);
                         t.setTargetSpeed(0);
+                        if (t instanceof Locomotive) {
+                            ((Locomotive) t).setForceIdleSound(true);
+                        }
                     });
                     this.setStalled(true);
                     Train otherTrain = blockingLinker.getTrain();
@@ -796,6 +799,7 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                             ((Locomotive) l).setTargetSpeed(0);
                             ((Locomotive) l).setAcousticSpeedSignal(-1);
                             ((Locomotive) l).setEngineTransitioning(false);
+                            ((Locomotive) l).setForceIdleSound(true);
                         }
                         l.destroy();
                     });
@@ -810,6 +814,7 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                     if (t instanceof Locomotive) {
                         ((Locomotive) t).setAcousticSpeedSignal(-1);
                         ((Locomotive) t).setEngineTransitioning(false);
+                        ((Locomotive) t).setForceIdleSound(true);
                     }
                 });
                 this.setStalled(true);
@@ -842,6 +847,7 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                 if (l instanceof Locomotive) {
                     ((Locomotive) l).setCurrentSpeed(0);
                     ((Locomotive) l).setTargetSpeed(0);
+                    ((Locomotive) l).setForceIdleSound(true);
                 }
                 l.destroy();
             });
@@ -863,6 +869,7 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                     if (l instanceof Locomotive) {
                         ((Locomotive) l).setCurrentSpeed(0);
                         ((Locomotive) l).setTargetSpeed(0);
+                        ((Locomotive) l).setForceIdleSound(true);
                     }
                     l.destroy();
                 });

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -498,6 +498,15 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
             return false;
         }
 
+        // Prevent any movement while the train is stalled from a collision or dead-end.
+        if (isStalled()) {
+            // Ensure tractors stay at idle when stalled.
+            if (directorLinker != null) {
+                directorLinker.setTargetSpeed(0);
+            }
+            return false;
+        }
+
         if (model != null) {
             if (!safetyManager.checkSafety((letrain.mvp.impl.Model) model)) {
                 // Si la seguridad falla, forzamos el frenado.

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -765,6 +765,40 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                     }
                 }
             }
+        } else {
+            // Train has reached a dead-end (no track connected ahead).
+            // Treat as collision: crash at high speed, contact at low speed.
+            int speed = getSpeed();
+            letrain.map.Point impactPos = firstLinker.getPosition();
+            if (Math.abs(speed) >= 5) {
+                // High-speed crash into dead-end -> destruction of THIS train
+                boolean alreadyDestroying = false;
+                for (Linker l : getLinkers()) {
+                    if (l instanceof Destructible && ((Destructible) l).isDestroying()) {
+                        alreadyDestroying = true;
+                        break;
+                    }
+                }
+                if (!alreadyDestroying) {
+                    notifyCrash(impactPos, speed);
+                    getLinkers().forEach(l -> {
+                        if (l instanceof Locomotive) {
+                            ((Locomotive) l).setCurrentSpeed(0);
+                            ((Locomotive) l).setTargetSpeed(0);
+                        }
+                        l.destroy();
+                    });
+                    this.setStalled(true);
+                }
+            } else {
+                // Low-speed contact with dead-end -> stop without destruction
+                notifyContact(impactPos, speed);
+                getTractors().forEach(t -> {
+                    t.setCurrentSpeed(0);
+                    t.setTargetSpeed(0);
+                });
+                this.setStalled(true);
+            }
         }
 
         return true;

--- a/src/test/java/letrain/vehicle/impl/rail/TrainDeadEndCrashTest.java
+++ b/src/test/java/letrain/vehicle/impl/rail/TrainDeadEndCrashTest.java
@@ -3,6 +3,7 @@ package letrain.vehicle.impl.rail;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -123,12 +124,15 @@ class TrainDeadEndCrashTest {
         // --- Assert ---
         // 1. notifyCrash was invoked (via listener.onCrash)
         verify(listener).onCrash(eq(train), any(Point.class), eq(8));
-        // 2. loco.destroy() was called
+        // 2. Acoustic/idle state is reset so engine goes to idle immediately
+        verify(loco).setAcousticSpeedSignal(-1);
+        verify(loco).setEngineTransitioning(false);
+        // 3. loco.destroy() was called
         verify(loco).destroy();
-        // 3. Train is stalled
+        // 4. Train is stalled
         assertTrue(train.isStalled(),
                 "Train should be stalled after high-speed dead-end crash");
-        // 4. notifyContact should NOT be called
+        // 5. notifyContact should NOT be called
         verify(listener, never()).onContact(any(Train.class), any(Point.class), anyInt());
     }
 
@@ -217,16 +221,19 @@ class TrainDeadEndCrashTest {
         // --- Assert ---
         // 1. notifyContact was invoked (via listener.onContact)
         verify(listener).onContact(eq(train), any(Point.class), eq(3));
-        // 2. Speed was set to 0 on the tractors (called by both notifyContact and the
+        // 2. Acoustic/idle state is reset so engine goes to idle immediately
+        verify(loco).setAcousticSpeedSignal(-1);
+        verify(loco).setEngineTransitioning(false);
+        // 3. Speed was set to 0 on the tractors (called by both notifyContact and the
         //    dead-end handler, consistent with existing train-to-train contact logic)
         verify(loco, org.mockito.Mockito.atLeast(1)).setCurrentSpeed(0);
         verify(loco, org.mockito.Mockito.atLeast(1)).setTargetSpeed(0);
-        // 3. Train is stalled
+        // 4. Train is stalled
         assertTrue(train.isStalled(),
                 "Train should be stalled after low-speed dead-end contact");
-        // 4. notifyCrash should NOT be called
+        // 5. notifyCrash should NOT be called
         verify(listener, never()).onCrash(any(Train.class), any(Point.class), anyInt());
-        // 5. destroy() should NOT be called on linkers
+        // 6. destroy() should NOT be called on linkers
         verify(loco, never()).destroy();
     }
 
@@ -323,5 +330,102 @@ class TrainDeadEndCrashTest {
         // 4. Train should NOT be stalled (normal movement)
         assertFalse(train.isStalled(),
                 "Train should not be stalled after normal movement");
+    }
+
+    // ================================================================
+    //  Test 4: Reverse (marcha atrás) into dead-end → engine goes idle
+    // ================================================================
+
+    @Test
+    @DisplayName("should go idle when reversing into a dead-end")
+    void shouldContact_When_DeadEndInReverse() {
+        // --- Arrange ---
+        Train train = new Train(1);
+        Locomotive loco = mock(Locomotive.class);
+        Track trackA = mock(Track.class); // dead-end behind
+        Track trackB = mock(Track.class); // current position
+
+        AtomicReference<Linker> linkerOnA = new AtomicReference<>(null);
+        AtomicReference<Linker> linkerOnB = new AtomicReference<>(loco);
+        AtomicReference<Track> locoTrack = new AtomicReference<>(trackB);
+
+        // Loco heading WEST (backward / marcha atrás)
+        when(loco.getDir()).thenReturn(Dir.W);
+        when(loco.getTrain()).thenReturn(train);
+        when(loco.getPosition()).thenReturn(new Point(0, 0));
+        when(loco.getRailsSinceStop()).thenReturn(0);
+        when(loco.getSpeed()).thenReturn(3); // low speed < 5
+
+        when(loco.getTrack()).thenAnswer(inv -> locoTrack.get());
+        doAnswer(inv -> { locoTrack.set(inv.getArgument(0)); return null; })
+                .when(loco).setTrack(any(Track.class));
+
+        doNothing().when(loco).setPreviousTrack(any(Track.class));
+        doNothing().when(loco).setPreviousDir(any(Dir.class));
+        doNothing().when(loco).setEntryDir(any(Dir.class));
+        doNothing().when(loco).setDir(any(Dir.class));
+        doNothing().when(loco).setPosition(any(Point.class));
+        doNothing().when(loco).setRailsSinceStop(anyInt());
+        doNothing().when(loco).setCurrentSpeed(anyInt());
+        doNothing().when(loco).setTargetSpeed(anyInt());
+        doNothing().when(loco).setAcousticSpeedSignal(anyInt());
+        doNothing().when(loco).setEngineTransitioning(anyBoolean());
+
+        // Track B → Track A (moving WEST), but A is dead-end (no connection W)
+        when(trackB.getPosition()).thenReturn(new Point(1, 0));
+        when(trackA.getPosition()).thenReturn(new Point(0, 0));
+        when(trackB.getConnected(Dir.W)).thenReturn(trackA);
+        when(trackA.getConnected(Dir.W)).thenReturn(null); // dead-end behind
+
+        when(trackB.getSensor()).thenReturn(null);
+        when(trackB.getSemaphore()).thenReturn(null);
+        when(trackA.getSensor()).thenReturn(null);
+        when(trackA.getSemaphore()).thenReturn(null);
+
+        doNothing().when(trackB).setReservation(any(Linker.class));
+        doNothing().when(trackA).setReservation(any(Linker.class));
+        when(trackB.getReservation()).thenReturn(null);
+        when(trackA.getReservation()).thenReturn(null);
+
+        when(trackB.getLinker()).thenAnswer(inv -> linkerOnB.get());
+        when(trackA.getLinker()).thenAnswer(inv -> linkerOnA.get());
+        when(trackA.canEnter(any(Dir.class), any(Linker.class))).thenReturn(true);
+
+        doAnswer(inv -> {
+            linkerOnB.set(null);
+            return loco;
+        }).when(trackB).removeLinker();
+
+        doAnswer(inv -> {
+            Linker v = inv.getArgument(1);
+            locoTrack.set(trackA);
+            linkerOnA.set(v);
+            return true;
+        }).when(trackA).enterLinkerFromDir(any(Dir.class), any(Linker.class));
+
+        train.getLinkers().add(loco);
+        train.setDirectorLinker(loco);
+
+        TrainEventListener listener = mock(TrainEventListener.class);
+        train.addTrainEventListener(listener);
+
+        // --- Act ---
+        train.moveLinkers(false);
+
+        // --- Assert ---
+        // 1. Contact notification (low speed + dead-end = contact, not crash)
+        verify(listener).onContact(eq(train), any(Point.class), eq(3));
+        // 2. Engine goes idle: acoustic signals reset
+        verify(loco).setAcousticSpeedSignal(-1);
+        verify(loco).setEngineTransitioning(false);
+        // 3. Speed set to 0
+        verify(loco, org.mockito.Mockito.atLeast(1)).setCurrentSpeed(0);
+        verify(loco, org.mockito.Mockito.atLeast(1)).setTargetSpeed(0);
+        // 4. Train is stalled
+        assertTrue(train.isStalled(),
+                "Train should be stalled after reversing into dead-end");
+        // 5. No crash
+        verify(listener, never()).onCrash(any(Train.class), any(Point.class), anyInt());
+        verify(loco, never()).destroy();
     }
 }

--- a/src/test/java/letrain/vehicle/impl/rail/TrainDeadEndCrashTest.java
+++ b/src/test/java/letrain/vehicle/impl/rail/TrainDeadEndCrashTest.java
@@ -127,6 +127,7 @@ class TrainDeadEndCrashTest {
         // 2. Acoustic/idle state is reset so engine goes to idle immediately
         verify(loco).setAcousticSpeedSignal(-1);
         verify(loco).setEngineTransitioning(false);
+        verify(loco).setForceIdleSound(true);
         // 3. loco.destroy() was called
         verify(loco).destroy();
         // 4. Train is stalled
@@ -224,6 +225,7 @@ class TrainDeadEndCrashTest {
         // 2. Acoustic/idle state is reset so engine goes to idle immediately
         verify(loco).setAcousticSpeedSignal(-1);
         verify(loco).setEngineTransitioning(false);
+        verify(loco).setForceIdleSound(true);
         // 3. Speed was set to 0 on the tractors (called by both notifyContact and the
         //    dead-end handler, consistent with existing train-to-train contact logic)
         verify(loco, org.mockito.Mockito.atLeast(1)).setCurrentSpeed(0);
@@ -418,6 +420,7 @@ class TrainDeadEndCrashTest {
         // 2. Engine goes idle: acoustic signals reset
         verify(loco).setAcousticSpeedSignal(-1);
         verify(loco).setEngineTransitioning(false);
+        verify(loco).setForceIdleSound(true);
         // 3. Speed set to 0
         verify(loco, org.mockito.Mockito.atLeast(1)).setCurrentSpeed(0);
         verify(loco, org.mockito.Mockito.atLeast(1)).setTargetSpeed(0);

--- a/src/test/java/letrain/vehicle/impl/rail/TrainDeadEndCrashTest.java
+++ b/src/test/java/letrain/vehicle/impl/rail/TrainDeadEndCrashTest.java
@@ -1,0 +1,327 @@
+package letrain.vehicle.impl.rail;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import letrain.map.Dir;
+import letrain.map.Point;
+import letrain.track.Track;
+import letrain.vehicle.Destructible;
+import letrain.vehicle.impl.Linker;
+import letrain.vehicle.impl.Tractor;
+
+@DisplayName("Train.moveLinkers() — Dead-end crash/contact tests")
+class TrainDeadEndCrashTest {
+
+    // ================================================================
+    //  Test 1: High-speed crash into dead-end
+    // ================================================================
+
+    @Test
+    @DisplayName("should crash when reaching a dead-end at high speed (|speed| >= 5)")
+    void shouldCrash_When_DeadEndAtHighSpeed() {
+        // --- Arrange ---
+        Train train = new Train(1);
+        Locomotive loco = mock(Locomotive.class);
+        Track trackA = mock(Track.class);
+        Track trackB = mock(Track.class);
+
+        // Track references to simulate real getLinker/setLinker side effects
+        AtomicReference<Linker> linkerOnA = new AtomicReference<>(loco);
+        AtomicReference<Linker> linkerOnB = new AtomicReference<>(null);
+        AtomicReference<Track> locoTrack = new AtomicReference<>(trackA);
+
+        // --- Linker (Locomotive) stubs ---
+        when(loco.getDir()).thenReturn(Dir.E);
+        when(loco.getTrain()).thenReturn(train);
+        when(loco.getPosition()).thenReturn(new Point(1, 0));
+        when(loco.getRailsSinceStop()).thenReturn(0);
+        when(loco.getSpeed()).thenReturn(8); // high speed ≥ 5
+        // isDestroying defaults to false (Mockito default for boolean)
+        doNothing().when(loco).destroy(); // no-op, but verifiable
+
+        // getTrack / setTrack correlation
+        when(loco.getTrack()).thenAnswer(inv -> locoTrack.get());
+        doAnswer(inv -> { locoTrack.set(inv.getArgument(0)); return null; })
+                .when(loco).setTrack(any(Track.class));
+
+        // Other linker setters
+        doNothing().when(loco).setPreviousTrack(any(Track.class));
+        doNothing().when(loco).setPreviousDir(any(Dir.class));
+        doNothing().when(loco).setEntryDir(any(Dir.class));
+        doNothing().when(loco).setDir(any(Dir.class));
+        doNothing().when(loco).setPosition(any(Point.class));
+        doNothing().when(loco).setRailsSinceStop(anyInt());
+        doNothing().when(loco).setCurrentSpeed(anyInt());
+        doNothing().when(loco).setTargetSpeed(anyInt());
+
+        // --- Track stubs ---
+        when(trackA.getPosition()).thenReturn(new Point(0, 0));
+        when(trackB.getPosition()).thenReturn(new Point(1, 0));
+
+        // Connection: trackA → trackB, but trackB is dead-end
+        when(trackA.getConnected(Dir.E)).thenReturn(trackB);
+        when(trackB.getConnected(Dir.E)).thenReturn(null);
+
+        // Sensors/semaphores: none
+        when(trackA.getSensor()).thenReturn(null);
+        when(trackA.getSemaphore()).thenReturn(null);
+        when(trackB.getSensor()).thenReturn(null);
+        when(trackB.getSemaphore()).thenReturn(null);
+
+        // Reservations
+        doNothing().when(trackA).setReservation(any(Linker.class));
+        doNothing().when(trackB).setReservation(any(Linker.class));
+        when(trackA.getReservation()).thenReturn(null);
+        when(trackB.getReservation()).thenReturn(null);
+
+        // Pass 1: trackB is empty, canEnter returns true
+        when(trackA.getLinker()).thenAnswer(inv -> linkerOnA.get());
+        when(trackB.getLinker()).thenAnswer(inv -> linkerOnB.get());
+        when(trackB.canEnter(any(Dir.class), any(Linker.class))).thenReturn(true);
+
+        // Pass 2: removeLinker from trackA
+        doAnswer(inv -> {
+            Linker removed = linkerOnA.get();
+            linkerOnA.set(null);
+            return removed;
+        }).when(trackA).removeLinker();
+
+        // Pass 2: enterLinkerFromDir on trackB (simulates real behavior)
+        doAnswer(inv -> {
+            Linker v = inv.getArgument(1);
+            locoTrack.set(trackB);
+            linkerOnB.set(v);
+            return true;
+        }).when(trackB).enterLinkerFromDir(any(Dir.class), any(Linker.class));
+
+        // Add loco to train and set as director
+        train.getLinkers().add(loco);
+        train.setDirectorLinker(loco);
+
+        // Add mock listener to verify notifyCrash
+        TrainEventListener listener = mock(TrainEventListener.class);
+        train.addTrainEventListener(listener);
+
+        // --- Act ---
+        train.moveLinkers(true);
+
+        // --- Assert ---
+        // 1. notifyCrash was invoked (via listener.onCrash)
+        verify(listener).onCrash(eq(train), any(Point.class), eq(8));
+        // 2. loco.destroy() was called
+        verify(loco).destroy();
+        // 3. Train is stalled
+        assertTrue(train.isStalled(),
+                "Train should be stalled after high-speed dead-end crash");
+        // 4. notifyContact should NOT be called
+        verify(listener, never()).onContact(any(Train.class), any(Point.class), anyInt());
+    }
+
+    // ================================================================
+    //  Test 2: Low-speed contact with dead-end
+    // ================================================================
+
+    @Test
+    @DisplayName("should contact when reaching a dead-end at low speed (|speed| < 5)")
+    void shouldContact_When_DeadEndAtLowSpeed() {
+        // --- Arrange ---
+        Train train = new Train(1);
+        Locomotive loco = mock(Locomotive.class);
+        Track trackA = mock(Track.class);
+        Track trackB = mock(Track.class);
+
+        AtomicReference<Linker> linkerOnA = new AtomicReference<>(loco);
+        AtomicReference<Linker> linkerOnB = new AtomicReference<>(null);
+        AtomicReference<Track> locoTrack = new AtomicReference<>(trackA);
+
+        // --- Linker (Locomotive) stubs ---
+        when(loco.getDir()).thenReturn(Dir.E);
+        when(loco.getTrain()).thenReturn(train);
+        when(loco.getPosition()).thenReturn(new Point(1, 0));
+        when(loco.getRailsSinceStop()).thenReturn(0);
+        when(loco.getSpeed()).thenReturn(3); // low speed < 5
+
+        // getTrack / setTrack
+        when(loco.getTrack()).thenAnswer(inv -> locoTrack.get());
+        doAnswer(inv -> { locoTrack.set(inv.getArgument(0)); return null; })
+                .when(loco).setTrack(any(Track.class));
+
+        // Other setters
+        doNothing().when(loco).setPreviousTrack(any(Track.class));
+        doNothing().when(loco).setPreviousDir(any(Dir.class));
+        doNothing().when(loco).setEntryDir(any(Dir.class));
+        doNothing().when(loco).setDir(any(Dir.class));
+        doNothing().when(loco).setPosition(any(Point.class));
+        doNothing().when(loco).setRailsSinceStop(anyInt());
+        doNothing().when(loco).setCurrentSpeed(anyInt());
+        doNothing().when(loco).setTargetSpeed(anyInt());
+
+        // --- Track stubs ---
+        when(trackA.getPosition()).thenReturn(new Point(0, 0));
+        when(trackB.getPosition()).thenReturn(new Point(1, 0));
+
+        when(trackA.getConnected(Dir.E)).thenReturn(trackB);
+        when(trackB.getConnected(Dir.E)).thenReturn(null); // dead-end
+
+        when(trackA.getSensor()).thenReturn(null);
+        when(trackA.getSemaphore()).thenReturn(null);
+        when(trackB.getSensor()).thenReturn(null);
+        when(trackB.getSemaphore()).thenReturn(null);
+
+        doNothing().when(trackA).setReservation(any(Linker.class));
+        doNothing().when(trackB).setReservation(any(Linker.class));
+        when(trackA.getReservation()).thenReturn(null);
+        when(trackB.getReservation()).thenReturn(null);
+
+        when(trackA.getLinker()).thenAnswer(inv -> linkerOnA.get());
+        when(trackB.getLinker()).thenAnswer(inv -> linkerOnB.get());
+        when(trackB.canEnter(any(Dir.class), any(Linker.class))).thenReturn(true);
+
+        doAnswer(inv -> {
+            linkerOnA.set(null);
+            return loco;
+        }).when(trackA).removeLinker();
+
+        doAnswer(inv -> {
+            Linker v = inv.getArgument(1);
+            locoTrack.set(trackB);
+            linkerOnB.set(v);
+            return true;
+        }).when(trackB).enterLinkerFromDir(any(Dir.class), any(Linker.class));
+
+        train.getLinkers().add(loco);
+        train.setDirectorLinker(loco);
+
+        // Listener to verify notifyContact (and absence of notifyCrash)
+        TrainEventListener listener = mock(TrainEventListener.class);
+        train.addTrainEventListener(listener);
+
+        // --- Act ---
+        train.moveLinkers(true);
+
+        // --- Assert ---
+        // 1. notifyContact was invoked (via listener.onContact)
+        verify(listener).onContact(eq(train), any(Point.class), eq(3));
+        // 2. Speed was set to 0 on the tractors (called by both notifyContact and the
+        //    dead-end handler, consistent with existing train-to-train contact logic)
+        verify(loco, org.mockito.Mockito.atLeast(1)).setCurrentSpeed(0);
+        verify(loco, org.mockito.Mockito.atLeast(1)).setTargetSpeed(0);
+        // 3. Train is stalled
+        assertTrue(train.isStalled(),
+                "Train should be stalled after low-speed dead-end contact");
+        // 4. notifyCrash should NOT be called
+        verify(listener, never()).onCrash(any(Train.class), any(Point.class), anyInt());
+        // 5. destroy() should NOT be called on linkers
+        verify(loco, never()).destroy();
+    }
+
+    // ================================================================
+    //  Test 3: Normal movement — next track exists, no dead-end
+    // ================================================================
+
+    @Test
+    @DisplayName("should not trigger crash/contact when next track exists (normal case)")
+    void shouldNotTrigger_When_NextTrackExists() {
+        // --- Arrange ---
+        Train train = new Train(1);
+        Linker linker = mock(Linker.class);
+        Track trackA = mock(Track.class);
+        Track trackB = mock(Track.class);
+        Track trackC = mock(Track.class);
+
+        AtomicReference<Linker> linkerOnA = new AtomicReference<>(linker);
+        AtomicReference<Linker> linkerOnB = new AtomicReference<>(null);
+        AtomicReference<Linker> linkerOnC = new AtomicReference<>(null);
+        AtomicReference<Track> linkerTrack = new AtomicReference<>(trackA);
+
+        // --- Linker stubs ---
+        when(linker.getDir()).thenReturn(Dir.E);
+        when(linker.getTrain()).thenReturn(train);
+        when(linker.getPosition()).thenReturn(new Point(1, 0));
+        when(linker.getRailsSinceStop()).thenReturn(0);
+
+        when(linker.getTrack()).thenAnswer(inv -> linkerTrack.get());
+        doAnswer(inv -> { linkerTrack.set(inv.getArgument(0)); return null; })
+                .when(linker).setTrack(any(Track.class));
+
+        doNothing().when(linker).setPreviousTrack(any(Track.class));
+        doNothing().when(linker).setPreviousDir(any(Dir.class));
+        doNothing().when(linker).setEntryDir(any(Dir.class));
+        doNothing().when(linker).setDir(any(Dir.class));
+        doNothing().when(linker).setPosition(any(Point.class));
+        doNothing().when(linker).setRailsSinceStop(anyInt());
+
+        // --- Track stubs ---
+        when(trackA.getPosition()).thenReturn(new Point(0, 0));
+        when(trackB.getPosition()).thenReturn(new Point(1, 0));
+        when(trackC.getPosition()).thenReturn(new Point(2, 0));
+
+        // Connections: trackA → trackB → trackC (NOT a dead-end)
+        when(trackA.getConnected(Dir.E)).thenReturn(trackB);
+        when(trackB.getConnected(Dir.E)).thenReturn(trackC);
+
+        when(trackA.getSensor()).thenReturn(null);
+        when(trackA.getSemaphore()).thenReturn(null);
+        when(trackB.getSensor()).thenReturn(null);
+        when(trackB.getSemaphore()).thenReturn(null);
+
+        doNothing().when(trackA).setReservation(any(Linker.class));
+        doNothing().when(trackB).setReservation(any(Linker.class));
+        when(trackA.getReservation()).thenReturn(null);
+        when(trackB.getReservation()).thenReturn(null);
+
+        when(trackA.getLinker()).thenAnswer(inv -> linkerOnA.get());
+        when(trackB.getLinker()).thenAnswer(inv -> linkerOnB.get());
+        when(trackB.canEnter(any(Dir.class), any(Linker.class))).thenReturn(true);
+
+        doAnswer(inv -> {
+            linkerOnA.set(null);
+            return linker;
+        }).when(trackA).removeLinker();
+
+        doAnswer(inv -> {
+            Linker v = inv.getArgument(1);
+            linkerTrack.set(trackB);
+            linkerOnB.set(v);
+            return true;
+        }).when(trackB).enterLinkerFromDir(any(Dir.class), any(Linker.class));
+
+        // trackC has no foreign linker — just return null (same train or empty)
+        when(trackC.getLinker()).thenAnswer(inv -> linkerOnC.get());
+
+        train.getLinkers().add(linker);
+
+        // Listener to verify no crash/contact is triggered
+        TrainEventListener listener = mock(TrainEventListener.class);
+        train.addTrainEventListener(listener);
+
+        // --- Act ---
+        boolean moved = train.moveLinkers(true);
+
+        // --- Assert ---
+        // 1. moveLinkers returns true (movement succeeded)
+        assertTrue(moved, "moveLinkers should return true when next track exists");
+        // 2. notifyCrash was NOT invoked by the dead-end code
+        verify(listener, never()).onCrash(any(Train.class), any(Point.class), anyInt());
+        // 3. notifyContact was NOT invoked by the dead-end code
+        verify(listener, never()).onContact(any(Train.class), any(Point.class), anyInt());
+        // 4. Train should NOT be stalled (normal movement)
+        assertFalse(train.isStalled(),
+                "Train should not be stalled after normal movement");
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #81: trains reaching a dead-end (end-of-track with no connected track ahead) now trigger crash/contact instead of entering the cell and getting stuck silently.
- Mirrors the existing train-to-train collision behavior: high speed (≥5) causes crash with destruction, low speed (<5) causes contact with stop.

## Root Cause
In `Train.moveLinkers()`, the post-move collision check only handled `nextAfterMove != null` (occupied track ahead). When `nextAfterMove == null` (dead-end), the code did nothing — the train entered the dead-end cell and got stuck without any collision logic.

## Changes
| File | Change |
|------|--------|
| `src/main/java/letrain/vehicle/impl/rail/Train.java` | Added `else` branch in post-move check: dead-end triggers crash (≥5) or contact (<5), consistent with train-to-train collision logic |
| `src/test/java/letrain/vehicle/impl/rail/TrainDeadEndCrashTest.java` | 3 new tests: high-speed crash, low-speed contact, normal movement |

## Verification
```
mvn clean test → BUILD SUCCESS
Tests run: 265, Failures: 0, Errors: 0, Skipped: 0
```