### PR TITLE
fix: critical bugs — null-check, dead code, visitor stubs

### DIFF
--- a/src/main/java/letrain/audio/core/DistanceAttenuator.java
+++ b/src/main/java/letrain/audio/core/DistanceAttenuator.java
@@ -30,18 +30,11 @@ public class DistanceAttenuator {
         while (angleRelative < -Math.PI)
             angleRelative += 2 * Math.PI;
 
-        // Simple pan: when angle is -PI/2 (Left), Left=1, Right=0.
-        // When 0 (Ahead), Left=1, Right=1. (Or 0.707 for constant power)
+        // Simple linear pan: -PI/2 (left) → pan=-1, 0 (ahead) → pan=0, +PI/2 (right) → pan=+1
+        float pan = (float) Math.sin(angleRelative);
 
-        float pan = (float) Math.sin(angleRelative); // -1 (Left) to 1 (Right)
-
-        // Constant power panning approx
-        float left = (float) ((Math.sqrt(2) / 2.0) * (Math.cos(angleRelative) + Math.sin(angleRelative))); // This is
-                                                                                                           // wrong
-                                                                                                           // formula
-        // Let's use simple linear for now
-
-        float p = (pan + 1.0f) / 2.0f; // 0 (Left) to 1 (Right)
+        // Map pan [-1, 1] to [0, 1] for left/right volume
+        float p = (pan + 1.0f) / 2.0f;
         return new float[] { 1.0f - p, p };
     }
 }

--- a/src/main/java/letrain/map/Point.java
+++ b/src/main/java/letrain/map/Point.java
@@ -30,7 +30,7 @@ public class Point {
 
     @Override
     public boolean equals(Object p) {
-        if (p.getClass() != Point.class) {
+        if (p == null || p.getClass() != Point.class) {
             return false;
         }
         Point q = (Point) p;

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
 public class Train implements Trailer<RailTrack>, Renderable, Transportable {
-    private static final int MAX_LOADING_COUNT = 80; // 4.0 seconds at 20fps per wagon
     private static final Logger log = LoggerFactory.getLogger(Train.class);
     @com.fasterxml.jackson.annotation.JsonProperty("linkers")
     @com.fasterxml.jackson.databind.annotation.JsonDeserialize(as = java.util.LinkedList.class)
@@ -1150,28 +1149,6 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
 
     public Deque<Linker> getLinkersToRemove() {
         return this.linkersToRemove;
-    }
-
-    // Devuelve la dirección en la que hay un linker que no pertenece al tren
-    Dir getLinkDir2(Linker linker) {
-        Dir linkerDir = linker.getDir();
-        Dir resultDir = linkerDir;
-        Train train = getAdjacentTrain(linker, linkerDir);
-        try {
-            if (train != this) {
-                return resultDir;
-            }
-            resultDir = linker.getTrack().getDir(resultDir);
-            train = getAdjacentTrain(linker, resultDir);
-            if (train != this) {
-                return resultDir;
-            }
-            log.error("Error getting link dir:" + resultDir + " train:" + train);
-            return null;
-        } catch (Exception e) {
-            log.error("Error getting link dir", e);
-            return null;
-        }
     }
 
     Dir getLinkDir(Linker linker) {

--- a/src/main/java/letrain/visitor/terminal/InfoVisitor.java
+++ b/src/main/java/letrain/visitor/terminal/InfoVisitor.java
@@ -241,20 +241,17 @@ public class InfoVisitor implements Visitor {
 
     @Override
     public void visitBridgeGateRailTrack(BridgeGateRailTrack bridgeGateRailTrack) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'visitBridgeGateRailTrack'");
+        // No extra info in terminal mode
     }
 
     @Override
     public void visitBridgeRailTrack(BridgeRailTrack bridgeRailTrack) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'visitBridgeRailTrack'");
+        // No extra info in terminal mode
     }
 
     @Override
     public void visitTunnelGateRailTrack(TunnelGateRailTrack tunnelGateRailTrack) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'visitTunnelGateRailTrack'");
+        // No extra info in terminal mode
     }
 
     @Override
@@ -265,8 +262,7 @@ public class InfoVisitor implements Visitor {
 
     @Override
     public void visitCursor(Cursor cursor) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'visitCursor'");
+        // No extra info in terminal mode
     }
 
 }

--- a/src/main/java/letrain/visitor/terminal/RenderVisitor.java
+++ b/src/main/java/letrain/visitor/terminal/RenderVisitor.java
@@ -514,8 +514,7 @@ public class RenderVisitor implements Visitor {
 
     @Override
     public void visitEconomyManager(EconomyManager economyManager) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'visitEconomyManager'");
+        // Not rendered in terminal mode
     }
 
 }


### PR DESCRIPTION
## Summary
Fixes all items from #83 (auditoría de bugs críticos).

| Fix | Archivo | Descripción |
|-----|---------|-------------|
| NPE | `Point.java` | `equals()` ahora comprueba `null` antes de `getClass()` |
| Dead code | `DistanceAttenuator.java` | Eliminada fórmula errónea comentada como `// wrong formula` |
| Visitor stub | `RenderVisitor.java` | `visitEconomyManager` → no-op en vez de `UnsupportedOperationException` |
| Visitor stubs ×4 | `InfoVisitor.java` | `visitBridgeGateRailTrack`, `visitBridgeRailTrack`, `visitTunnelGateRailTrack`, `visitCursor` → no-ops |
| Dead constant | `Train.java` | Eliminado `MAX_LOADING_COUNT` duplicado (solo se usa el de `TrainLogisticsManager`) |
| Dead method | `Train.java` | Eliminado `getLinkDir2()` — nunca llamado |

## Verification
```
mvn clean test → BUILD SUCCESS
Tests run: 259, Failures: 0, Errors: 0, Skipped: 0
```

Closes #83