### PR TITLE
refactor: extraer números mágicos a constantes con nombre

### DIFF
--- a/src/main/java/letrain/track/Station.java
+++ b/src/main/java/letrain/track/Station.java
@@ -15,6 +15,14 @@ import letrain.visitor.Visitor;
 @com.fasterxml.jackson.annotation.JsonTypeName("Station")
 public class Station extends Sensor implements TrainEventListener {
 
+    private static final int BASE_MAX_STORAGE = 500;
+    private static final int STORAGE_PER_INDUSTRY = 100;
+    private static final int BASE_REGEN_RATE = 1;
+    private static final int REGEN_RATE_PER_INDUSTRY_DIVISOR = 2;
+    private static final double CONSUMER_CONSUMPTION_CHANCE = 0.1;
+    private static final int BASE_TRANSFER_RATE = 1;
+    private static final int TRANSFER_RATE_PER_INDUSTRY_DIVISOR = 3;
+
     @JsonIgnore
     private transient List<StationEventListener> stationListeners = new ArrayList<>();
     @JsonIgnore
@@ -268,7 +276,7 @@ public class Station extends Sensor implements TrainEventListener {
     public void setIndustryCount(int industryCount) {
         this.industryCount = industryCount;
         // Base max storage 500 + 100 per additional industry block
-        this.maxStorage = 500 + (industryCount * 100);
+        this.maxStorage = BASE_MAX_STORAGE + (industryCount * STORAGE_PER_INDUSTRY);
     }
 
     public int getStorage() {
@@ -302,7 +310,7 @@ public class Station extends Sensor implements TrainEventListener {
     public void regenerateCargo() {
         if (role == CargoTypes.StationRole.PRODUCER && storage < maxStorage) {
             // Regeneration scales with density: Base + bonus per block
-            int increment = 1 + (industryCount / 2);
+            int increment = BASE_REGEN_RATE + (industryCount / REGEN_RATE_PER_INDUSTRY_DIVISOR);
             storage += increment;
             if (storage > maxStorage)
                 storage = maxStorage;
@@ -314,7 +322,7 @@ public class Station extends Sensor implements TrainEventListener {
         // Wait, storage for consumer = current STOCK received.
         // If storage is high, they are "full".
         if (role == CargoTypes.StationRole.CONSUMER && storage > 0) {
-            if (Math.random() < 0.1) {
+            if (Math.random() < CONSUMER_CONSUMPTION_CHANCE) {
                 storage--;
             }
         }
@@ -340,7 +348,7 @@ public class Station extends Sensor implements TrainEventListener {
     @JsonIgnore
     public int getTransferRate() {
         // Base transfer rate of 1, plus 1 for every 3 industry blocks
-        return 1 + (industryCount / 3);
+        return BASE_TRANSFER_RATE + (industryCount / TRANSFER_RATE_PER_INDUSTRY_DIVISOR);
     }
 
     @Override

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
 public class Train implements Trailer<RailTrack>, Renderable, Transportable {
+    private static final int CRASH_SPEED_THRESHOLD = 5;
     private static final int MAX_LOADING_COUNT = 80; // 4.0 seconds at 20fps per wagon
     private static final Logger log = LoggerFactory.getLogger(Train.class);
     @com.fasterxml.jackson.annotation.JsonProperty("linkers")
@@ -665,7 +666,7 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                 if (occupyingL.getTrain() != this) {
                     int speed = getSpeed();
 
-                    if (Math.abs(speed) >= 5) {
+                    if (Math.abs(speed) >= CRASH_SPEED_THRESHOLD) {
                         crash(occupyingL, speed);
                     } else {
                         letrain.map.Point collisionPos = occupyingL.getPosition();
@@ -748,11 +749,11 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
             Linker blockingLinker = nextAfterMove.getLinker();
             if (blockingLinker != null && blockingLinker.getTrain() != this) {
                 int speed = getSpeed();
-                if (Math.abs(speed) >= 5) {
-                    crash(blockingLinker, speed);
-                    this.setStalled(true);
-                } else {
-                    letrain.map.Point collisionPos = blockingLinker.getPosition();
+                    if (Math.abs(speed) >= CRASH_SPEED_THRESHOLD) {
+                        crash(blockingLinker, speed);
+                        this.setStalled(true);
+                    } else {
+                        letrain.map.Point collisionPos = blockingLinker.getPosition();
                     notifyContact(collisionPos, speed);
                     getTractors().forEach(t -> {
                         t.setCurrentSpeed(0);

--- a/src/main/java/letrain/vehicle/impl/rail/TrainLogisticsManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainLogisticsManager.java
@@ -132,7 +132,7 @@ public class TrainLogisticsManager {
         int wagonTick = (currentTickInTotal - 1) % MAX_LOADING_COUNT;
 
         if (station.getRole() == CargoTypes.StationRole.PRODUCER) {
-            int targetCargo = ((wagonTick + 1) * 50) / MAX_LOADING_COUNT;
+            int targetCargo = ((wagonTick + 1) * Wagon.MAX_CARGO_CAPACITY) / MAX_LOADING_COUNT;
             if (wagon.getCargoAmount() < targetCargo && !wagon.isFull()) {
                 int toLoad = targetCargo - wagon.getCargoAmount();
                 int taken = station.takeExportCargo(toLoad);
@@ -144,7 +144,7 @@ public class TrainLogisticsManager {
                 }
             }
         } else if (station.getRole() == CargoTypes.StationRole.CONSUMER) {
-            int targetRemaining = 50 - ((wagonTick + 1) * 50) / MAX_LOADING_COUNT;
+            int targetRemaining = Wagon.MAX_CARGO_CAPACITY - ((wagonTick + 1) * Wagon.MAX_CARGO_CAPACITY) / MAX_LOADING_COUNT;
             if (wagon.getCargoAmount() > targetRemaining && wagon.getCargoType() == station.getCargoType()) {
                 int toUnload = wagon.getCargoAmount() - targetRemaining;
                 wagon.unload(toUnload);

--- a/src/main/java/letrain/vehicle/impl/rail/Wagon.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Wagon.java
@@ -5,6 +5,8 @@ import letrain.vehicle.impl.Linker;
 import letrain.visitor.Visitor;
 
 public class Wagon extends Linker {
+    public static final int MAX_CARGO_CAPACITY = 50;
+    private static final int MAX_DESTROY_TURNS = 200;
     String aspect;
     float brakes;
     boolean destroying = false;
@@ -42,7 +44,7 @@ public class Wagon extends Linker {
     @Override
     public void destroy() {
         this.destroying = true;
-        this.destroyingTurns = 200;
+        this.destroyingTurns = MAX_DESTROY_TURNS;
     }
 
     @Override
@@ -62,7 +64,7 @@ public class Wagon extends Linker {
     }
 
     private int cargoAmount = 0;
-    private int maxCapacity = 50;
+    private int maxCapacity = MAX_CARGO_CAPACITY;
     private CargoTypes cargoType = CargoTypes.NONE;
     private CargoTypes exclusiveCargoType = CargoTypes.NONE;
     private letrain.map.Point loadingPoint = null;


### PR DESCRIPTION
## Summary
Extrae números mágicos repetidos a constantes con nombre. Fixes #84.

| Archivo | Constante | Valor | Ocurrencias |
|---------|-----------|-------|-------------|
| `Train.java` | `CRASH_SPEED_THRESHOLD` | 5 | 2 → constante |
| `Wagon.java` | `MAX_CARGO_CAPACITY` | 50 | campo + 2 refs en `TrainLogisticsManager` |
| `Wagon.java` | `MAX_DESTROY_TURNS` | 200 | hardcodeado → constante |
| `Station.java` | `BASE_MAX_STORAGE` | 500 | 1 |
| `Station.java` | `STORAGE_PER_INDUSTRY` | 100 | 1 |
| `Station.java` | `BASE_REGEN_RATE` | 1 | 1 |
| `Station.java` | `REGEN_RATE_PER_INDUSTRY_DIVISOR` | 2 | 1 |
| `Station.java` | `CONSUMER_CONSUMPTION_CHANCE` | 0.1 | 1 |
| `Station.java` | `BASE_TRANSFER_RATE` | 1 | 1 |
| `Station.java` | `TRANSFER_RATE_PER_INDUSTRY_DIVISOR` | 3 | 1 |

## Verification
```
mvn clean test → BUILD SUCCESS
Tests run: 259, Failures: 0
```

Closes #84