### PR TITLE
fix: restore linker directions when train stalls after dead-end crash (visual overlap)

### DIFF
--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -535,11 +535,11 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
         setDirTowedLinkers(normalSense);
         boolean moved = moveLinkers(normalSense);
 
-        if (!moved) {
-            // Movement failed — restore original directions.
-            // Without this, setDirTowedLinkers leaves wagons pointing
-            // forward, causing the renderer to interpolate them into
-            // the locomotive when the train has actually stopped.
+        if (!moved || isStalled()) {
+            // Movement failed or train crashed/stalled — restore original
+            // directions. Without this, setDirTowedLinkers leaves wagons
+            // pointing forward, causing the renderer to interpolate them
+            // into the locomotive when the train has actually stopped.
             for (Linker l : getLinkers()) {
                 letrain.map.Dir savedDir = savedDirs.get(l);
                 letrain.map.Dir savedEntry = savedEntryDirs.get(l);


### PR DESCRIPTION
## Summary

Fixes a visual bug where, after crashing into a dead-end, the leading vehicle appears "transparent" because the following vehicle's model overlaps it (z-fighting).

## Root Cause

The direction restoration in `advance()` only ran when `moveLinkers()` returned `false`. But the dead-end crash fix (#82) made `moveLinkers()` return `true` when the train moves into a dead-end and then crashes/contacts.

Without direction restoration, `setDirTowedLinkers`' modified directions persisted, causing the renderer to draw wagons at incorrect orientations — overlapping the locomotive model.

## Fix

One-line change in `advance()`: restore original linker directions when the train becomes stalled during movement, not just when movement fails:

```java
// Before:
if (!moved) {

// After:
if (!moved || isStalled()) {
```

## Verification
```
mvn clean test → BUILD SUCCESS
Tests run: 266, Failures: 0
```