### PR TITLE
refactor: rename Trackeable→Trackable, Mapeable→Mappable, Rotable→Rotatable

### DIFF
--- a/.opencode/skills/java-expert-mentor/references/patterns.md
+++ b/.opencode/skills/java-expert-mentor/references/patterns.md
@@ -2,9 +2,9 @@
 
 ## 1. Principios SOLID
 - **Single Responsibility (SRP)**: Cada clase (ej. `BlockManager`, `AudioController`) debe tener una sola razón para cambiar.
-- **Open/Closed (OCP)**: Las entidades deben estar abiertas a extensión pero cerradas a modificación. Usar interfaces para añadir nuevos comportamientos (ej. nuevos tipos de `Trackeable`).
+- **Open/Closed (OCP)**: Las entidades deben estar abiertas a extensión pero cerradas a modificación. Usar interfaces para añadir nuevos comportamientos (ej. nuevos tipos de `Trackable`).
 - **Liskov Substitution (LSP)**: Cualquier subclase (ej. `ForkRouter`) debe ser sustituible por su clase base (`Router`) sin romper el sistema.
-- **Interface Segregation (ISP)**: Interfaces pequeñas y específicas. En lugar de una interfaz gigante `Map`, tenemos `Mapeable`, `Reversible`, `Rotable`.
+- **Interface Segregation (ISP)**: Interfaces pequeñas y específicas. En lugar de una interfaz gigante `Map`, tenemos `Mappable`, `Reversible`, `Rotatable`.
 - **Dependency Inversion (DIP)**: Depender de abstracciones, no de implementaciones. (Inyección de dependencias).
 
 ## 2. Patrones de Comportamiento Aplicados

--- a/docs/architecture/ClassIndex.md
+++ b/docs/architecture/ClassIndex.md
@@ -37,12 +37,12 @@ Esta lista se genera automáticamente a partir de los archivos fuente presentes 
 - `letrain.ground.impl.Terrain2D`
 - `letrain.map.Dir`
 - `letrain.map.DynamicRouter`
-- `letrain.map.Mapeable`
+- `letrain.map.Mappable`
 - `letrain.map.Page`
 - `letrain.map.Point`
 - `letrain.map.RailMap`
 - `letrain.map.Reversible`
-- `letrain.map.Rotable`
+- `letrain.map.Rotatable`
 - `letrain.map.Router`
 - `letrain.map.impl.ForkRouter`
 - `letrain.map.impl.RailMap`
@@ -83,7 +83,7 @@ Esta lista se genera automáticamente a partir de los archivos fuente presentes 
 - `letrain.track.StationEventListener`
 - `letrain.track.Track`
 - `letrain.track.TrackDirector`
-- `letrain.track.Trackeable`
+- `letrain.track.Trackable`
 - `letrain.track.rail.BridgeGateRailTrack`
 - `letrain.track.rail.BridgeRailTrack`
 - `letrain.track.rail.ForkRailTrack`

--- a/src/main/java/letrain/ground/Ground.java
+++ b/src/main/java/letrain/ground/Ground.java
@@ -2,14 +2,14 @@ package letrain.ground;
 
 import java.io.Serializable;
 
-import letrain.map.Mapeable;
+import letrain.map.Mappable;
 import letrain.map.Point;
 import letrain.visitor.Renderable;
 import letrain.visitor.Visitor;
 
 public class Ground implements
         Serializable,
-        Mapeable,
+        Mappable,
         Renderable {
 
     int type;
@@ -42,7 +42,7 @@ public class Ground implements
     }
 
     /**************************************************************
-     * Mapeable implementation
+     * Mappable implementation
      ***************************************************************/
     @Override
     public Point getPosition() {

--- a/src/main/java/letrain/ground/impl/GroundMap.java
+++ b/src/main/java/letrain/ground/impl/GroundMap.java
@@ -7,15 +7,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import letrain.economy.EconomyManager;
 import letrain.ground.Ground;
 import letrain.ground.PerlinNoise;
 import letrain.map.Point;
 import letrain.visitor.Visitor;
-import letrain.economy.EconomyManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class GroundMap implements letrain.ground.GroundMap, Serializable {
@@ -105,8 +105,8 @@ public class GroundMap implements letrain.ground.GroundMap, Serializable {
         return -1;
     }
 
-    public void setValueAt(Point p, Integer value) {
-        setValueAt(p.getX(), p.getY(), value);
+    public void setValueAt(Point point, Integer value) {
+        setValueAt(point.getX(), point.getY(), value);
     }
 
     @Override
@@ -122,8 +122,8 @@ public class GroundMap implements letrain.ground.GroundMap, Serializable {
         }
     }
 
-    public Integer removeValueAt(Point p) {
-        return removeValueAt(p.getX(), p.getY());
+    public Integer removeValueAt(Point point) {
+        return removeValueAt(point.getX(), point.getY());
     }
 
     public Integer removeValueAt(int row, int col) {

--- a/src/main/java/letrain/map/Dir.java
+++ b/src/main/java/letrain/map/Dir.java
@@ -115,8 +115,8 @@ public enum Dir {
         return value;
     }
 
-    public int angularDistance(Dir d) {
-        return shortWay(d.value - this.value);
+    public int angularDistance(Dir dir) {
+        return shortWay(dir.value - this.value);
     }
 
     public Dir inverse() {

--- a/src/main/java/letrain/map/Mappable.java
+++ b/src/main/java/letrain/map/Mappable.java
@@ -1,6 +1,6 @@
 package letrain.map;
 
-public interface Mapeable {
+public interface Mappable {
     Point getPosition();
 
     void setPosition(Point pos);

--- a/src/main/java/letrain/map/Point.java
+++ b/src/main/java/letrain/map/Point.java
@@ -57,27 +57,27 @@ public class Point {
         this.y = y;
     }
 
-    public Dir locate(Point p) {
-        if (y > p.y) {
-            if (x > p.x) {
+    public Dir locate(Point point) {
+        if (y > point.y) {
+            if (x > point.x) {
                 return NW;
-            } else if (x < p.x) {
+            } else if (x < point.x) {
                 return NE;
             } else {
                 return N;
             }
-        } else if (y < p.y) {
-            if (x > p.x) {
+        } else if (y < point.y) {
+            if (x > point.x) {
                 return SW;
-            } else if (x < p.x) {
+            } else if (x < point.x) {
                 return SE;
             } else {
                 return S;
             }
         } else {// y == p.y
-            if (x > p.x) {
+            if (x > point.x) {
                 return W;
-            } else if (x < p.x) {
+            } else if (x < point.x) {
                 return E;
             } else {
                 return null;

--- a/src/main/java/letrain/map/RailMap.java
+++ b/src/main/java/letrain/map/RailMap.java
@@ -13,7 +13,7 @@ public interface RailMap<T> extends Renderable {
 
     T getTrackAt(Point pos);
 
-    void addTrack(Point p, T t);
+    void addTrack(Point point, T track);
 
-    T removeTrack(Point p);
+    T removeTrack(Point point);
 }

--- a/src/main/java/letrain/map/Rotatable.java
+++ b/src/main/java/letrain/map/Rotatable.java
@@ -1,6 +1,6 @@
 package letrain.map;
 
-public interface Rotable  {
+public interface Rotatable {
     void rotateLeft();
 
     void rotateLeft(int angle);

--- a/src/main/java/letrain/map/impl/RailMap.java
+++ b/src/main/java/letrain/map/impl/RailMap.java
@@ -3,9 +3,9 @@ package letrain.map.impl;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 import letrain.map.Point;
 import letrain.track.rail.RailTrack;
 import letrain.visitor.Renderable;
@@ -67,9 +67,9 @@ public class RailMap implements letrain.map.RailMap<RailTrack>, Renderable {
     }
 
     @Override
-    public void addTrack(Point p, RailTrack rail) {
-        int x = p.getX();
-        int y = p.getY();
+    public void addTrack(Point point, RailTrack rail) {
+        int x = point.getX();
+        int y = point.getY();
         if (!rails.containsKey(y)) {
             rails.put(y, new HashMap<>());
         }
@@ -84,9 +84,9 @@ public class RailMap implements letrain.map.RailMap<RailTrack>, Renderable {
     }
 
     @Override
-    public RailTrack removeTrack(Point p) {
-        RailTrack ret = getTrackAt(p);
-        rails.get(p.getY()).remove(p.getX());
+    public RailTrack removeTrack(Point point) {
+        RailTrack ret = getTrackAt(point);
+        rails.get(point.getY()).remove(point.getX());
         return ret;
     }
 

--- a/src/main/java/letrain/mvp/Model.java
+++ b/src/main/java/letrain/mvp/Model.java
@@ -40,9 +40,9 @@ public interface Model {
 
     public int nextTrainId();
 
-    void addTrack(Point p, RailTrack track);
+    void addTrack(Point point, RailTrack track);
 
-    RailTrack removeTrack(Point p);
+    RailTrack removeTrack(Point point);
 
     RailMap getRailMap();
 
@@ -64,9 +64,9 @@ public interface Model {
 
     List<Station> getStations();
 
-    void addStation(Station Station);
+    void addStation(Station station);
 
-    void removeStation(Station Station);
+    void removeStation(Station station);
 
     Station getStation(int id);
 
@@ -219,7 +219,7 @@ public interface Model {
     boolean isXRayActive();
     void setXRayActive(boolean xRayActive);
 
-    void updateGroundMap(Point p, int type, int variation);
+    void updateGroundMap(Point point, int type, int variation);
 
     boolean isMapChanged();
     void setMapChanged(boolean mapChanged);

--- a/src/main/java/letrain/mvp/impl/Model.java
+++ b/src/main/java/letrain/mvp/impl/Model.java
@@ -1,12 +1,11 @@
 package letrain.mvp.impl;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import letrain.core.segments.RailwayGraph;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import letrain.core.segments.TopologyService;
 import letrain.core.segments.impl.TopologyServiceImpl;
 import letrain.economy.EconomyManager;
@@ -243,8 +242,8 @@ public class Model implements letrain.mvp.Model {
 
     @Override public RailMap getRailMap() { return map; }
 
-    @Override public void addTrack(Point p, RailTrack track) {
-        map.addTrack(p, track);
+    @Override public void addTrack(Point point, RailTrack track) {
+        map.addTrack(point, track);
         if (track instanceof ForkRailTrack) {
             addFork((ForkRailTrack) track);
         }
@@ -261,8 +260,8 @@ public class Model implements letrain.mvp.Model {
         mapChanged = true;
     }
 
-    @Override public RailTrack removeTrack(Point p) {
-        RailTrack track = map.getTrackAt(p);
+    @Override public RailTrack removeTrack(Point point) {
+        RailTrack track = map.getTrackAt(point);
         if (track != null) {
             if (track.getSensor() != null) {
                 if (track.getSensor() instanceof Station) {
@@ -277,7 +276,7 @@ public class Model implements letrain.mvp.Model {
             if (track instanceof ForkRailTrack) {
                 removeFork((ForkRailTrack) track);
             }
-            map.removeTrack(p);
+            map.removeTrack(point);
             mapChanged = true;
         }
         return track;
@@ -610,17 +609,17 @@ public class Model implements letrain.mvp.Model {
         });
     }
 
-    @Override public void removeStation(Station Station) {
-        if (stations.remove(Station)) {
-            if (Station.getTrack() != null) {
-                Station.getTrack().setSensor(null);
+    @Override public void removeStation(Station station) {
+        if (stations.remove(station)) {
+            if (station.getTrack() != null) {
+                station.getTrack().setSensor(null);
             }
             getEconomyManager().onStationDestroyed();
             mapChanged = true;
         }
     }
     @Override public Station getStation(int id) {
-        for (Station Station : getStations()) { if (Station.getId() == id) return Station; }
+        for (Station station : getStations()) { if (station.getId() == id) return station; }
         return null;
     }
 

--- a/src/main/java/letrain/mvp/impl/RailTrackMaker.java
+++ b/src/main/java/letrain/mvp/impl/RailTrackMaker.java
@@ -25,10 +25,8 @@ import letrain.track.rail.TunnelGateRailTrack;
 import letrain.track.rail.TunnelRailTrack;
 import letrain.vehicle.impl.Cursor;
 import letrain.vehicle.impl.Cursor.CursorMode;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import letrain.core.segments.impl.TopologyServiceImpl;
 
 public class RailTrackMaker {
     private static final Logger log = LoggerFactory.getLogger(RailTrackMaker.class);
@@ -333,8 +331,8 @@ public class RailTrackMaker {
                 newPos.move(presenter.getModel().getCursor().getDir().inverse());
             }
             updateCursorPosition(newPos);
-            Point p = presenter.getModel().getCursor().getPosition();
-            presenter.getView().setPageOfPos(p.getX(), p.getY());
+            Point point = presenter.getModel().getCursor().getPosition();
+            presenter.getView().setPageOfPos(point.getX(), point.getY());
         }
     }
 
@@ -360,9 +358,9 @@ public class RailTrackMaker {
         }
 
         if (caterpillarCounter > 0) {
-            Point p = presenter.getModel().getCursor().getPosition();
+            Point point = presenter.getModel().getCursor().getPosition();
             if (presenter.getAudioController() != null) {
-                presenter.getAudioController().setJackhammerActive(true, p.getX(), p.getY());
+                presenter.getAudioController().setJackhammerActive(true, point.getX(), point.getY());
             }
             caterpillarCounter--;
         } else {
@@ -586,12 +584,12 @@ public class RailTrackMaker {
     }
 
     void addTrackConnectionsToFork(RailTrack track, final ForkRailTrack fork) {
-        for (Dir d : Dir.values()) {
-            if (track.getConnected(d) != null) {
-                Track connectedTrack = track.getConnected(d);
-                connectedTrack.disconnect(d.inverse());
-                connectedTrack.connect(d.inverse(), fork);
-                fork.connect(d, connectedTrack);
+        for (Dir dir : Dir.values()) {
+            if (track.getConnected(dir) != null) {
+                Track connectedTrack = track.getConnected(dir);
+                connectedTrack.disconnect(dir.inverse());
+                connectedTrack.connect(dir.inverse(), fork);
+                fork.connect(dir, connectedTrack);
             }
         }
     }
@@ -694,40 +692,40 @@ public class RailTrackMaker {
 
     void mapPageDown() {
         presenter.getView().clear();
-        Point p = presenter.getView().getMapScrollPage();
-        p.setY(p.getY() + 1);
+        Point point = presenter.getView().getMapScrollPage();
+        point.setY(point.getY() + 1);
         varyCursorPosition(new Point(0, 1 * presenter.getView().getRows()));
-        presenter.getView().setMapScrollPage(p);
+        presenter.getView().setMapScrollPage(point);
         presenter.getView().clear();
 
     }
 
     void mapPageLeft() {
         presenter.getView().clear();
-        Point p = presenter.getView().getMapScrollPage();
-        p.setX(p.getX() - 1);
+        Point point = presenter.getView().getMapScrollPage();
+        point.setX(point.getX() - 1);
         varyCursorPosition(new Point((-1 * presenter.getView().getCols()), 0));
-        presenter.getView().setMapScrollPage(p);
+        presenter.getView().setMapScrollPage(point);
         presenter.getView().clear();
 
     }
 
     void mapPageUp() {
         presenter.getView().clear();
-        Point p = presenter.getView().getMapScrollPage();
-        p.setY(p.getY() - 1);
+        Point point = presenter.getView().getMapScrollPage();
+        point.setY(point.getY() - 1);
         varyCursorPosition(new Point(0, -1 * presenter.getView().getRows()));
-        presenter.getView().setMapScrollPage(p);
+        presenter.getView().setMapScrollPage(point);
         presenter.getView().clear();
 
     }
 
     void mapPageRight() {
         presenter.getView().clear();
-        Point p = presenter.getView().getMapScrollPage();
-        p.setX(p.getX() + 1);
+        Point point = presenter.getView().getMapScrollPage();
+        point.setX(point.getX() + 1);
         varyCursorPosition(new Point((1 * presenter.getView().getCols()), 0));
-        presenter.getView().setMapScrollPage(p);
+        presenter.getView().setMapScrollPage(point);
         presenter.getView().clear();
 
     }

--- a/src/main/java/letrain/mvp/impl/graphic/CameraController.java
+++ b/src/main/java/letrain/mvp/impl/graphic/CameraController.java
@@ -1,10 +1,10 @@
 package letrain.mvp.impl.graphic;
 
-import letrain.mvp.Model;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
+import letrain.mvp.Model;
 import letrain.utils.PathGeometry;
 
 /**
@@ -172,9 +172,9 @@ public class CameraController {
             float x = interpPos.x + 0.5f;
             float z = interpPos.y + 0.5f;
 
-            letrain.map.Dir d = loco.getDir();
-            float dx = PathGeometry.getDirX(d);
-            float dz = PathGeometry.getDirZ(d);
+            letrain.map.Dir dir = loco.getDir();
+            float dx = PathGeometry.getDirX(dir);
+            float dz = PathGeometry.getDirZ(dir);
 
             Vector2 targetDir = new Vector2(dx, dz);
             currentCabDirection.lerp(targetDir, 0.05f).nor();

--- a/src/main/java/letrain/mvp/impl/terminal/TerminalPresenter.java
+++ b/src/main/java/letrain/mvp/impl/terminal/TerminalPresenter.java
@@ -15,17 +15,19 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import letrain.mvp.impl.GameSaveService;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import letrain.mvp.Model;
 
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
 import letrain.map.Dir;
 import letrain.map.Page;
 import letrain.map.Point;
+import letrain.mvp.Model;
+import letrain.mvp.impl.GameSaveService;
+import letrain.mvp.impl.RailTrackMaker;
+import letrain.mvp.impl.SimulationController;
 import letrain.track.CargoTypes;
 import letrain.track.Station;
 import letrain.track.rail.RailTrack;
@@ -39,8 +41,6 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import letrain.mvp.impl.SimulationController;
-import letrain.mvp.impl.RailTrackMaker;
 
 public class TerminalPresenter implements letrain.mvp.Presenter, letrain.vehicle.impl.rail.TrainEventListener {
     Logger log = LoggerFactory.getLogger(TerminalPresenter.class);
@@ -894,41 +894,41 @@ public class TerminalPresenter implements letrain.mvp.Presenter, letrain.vehicle
 
     private void mapPageDown() {
         view.clear();
-        Point p = view.getMapScrollPage();
-        p.setY(p.getY() + 1);
-        view.setMapScrollPage(p);
+        Point point = view.getMapScrollPage();
+        point.setY(point.getY() + 1);
+        view.setMapScrollPage(point);
         view.clear();
     }
 
     private void mapPageLeft() {
         view.clear();
-        Point p = view.getMapScrollPage();
-        p.setX(p.getX() - 1);
-        view.setMapScrollPage(p);
+        Point point = view.getMapScrollPage();
+        point.setX(point.getX() - 1);
+        view.setMapScrollPage(point);
         view.clear();
 
     }
 
     private void mapPageUp() {
         view.clear();
-        Point p = view.getMapScrollPage();
-        p.setY(p.getY() - 1);
-        view.setMapScrollPage(p);
+        Point point = view.getMapScrollPage();
+        point.setY(point.getY() - 1);
+        view.setMapScrollPage(point);
         view.clear();
     }
 
     private void mapPageRight() {
         view.clear();
-        Point p = view.getMapScrollPage();
-        p.setX(p.getX() + 1);
-        view.setMapScrollPage(p);
+        Point point = view.getMapScrollPage();
+        point.setX(point.getX() + 1);
+        view.setMapScrollPage(point);
         view.clear();
 
     }
 
-    void setPageOfPoint(Point p) {
-        view.setPageOfPos(p.getX(), p.getY());
-        Page page = p.getPage();
+    void setPageOfPoint(Point point) {
+        view.setPageOfPos(point.getX(), point.getY());
+        Page page = point.getPage();
         railTrackMaker.setCursorPage(page);
     }
 

--- a/src/main/java/letrain/track/LinkerCompartment.java
+++ b/src/main/java/letrain/track/LinkerCompartment.java
@@ -4,7 +4,7 @@ import letrain.map.Dir;
 import letrain.vehicle.impl.Linker;
 
 interface LinkerCompartment<T extends Track> {
-    boolean enterLinkerFromDir(Dir d, Linker t);
+    boolean enterLinkerFromDir(Dir dir, Linker t);
 
     Linker removeLinker();
 

--- a/src/main/java/letrain/track/LinkerCompartmentListener.java
+++ b/src/main/java/letrain/track/LinkerCompartmentListener.java
@@ -4,8 +4,8 @@ import letrain.map.Dir;
 import letrain.vehicle.impl.Linker;
 
 interface LinkerCompartmentListener {
-    boolean canEnter(Dir d, Linker v);
+    boolean canEnter(Dir dir, Linker v);
 
-    boolean canExit(Dir d);
+    boolean canExit(Dir dir);
 
 }

--- a/src/main/java/letrain/track/Track.java
+++ b/src/main/java/letrain/track/Track.java
@@ -1,17 +1,17 @@
 package letrain.track;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-
 import letrain.map.Dir;
-import letrain.map.Mapeable;
+import letrain.map.Mappable;
 import letrain.map.Point;
 import letrain.map.Router;
 import letrain.utils.Pair;
@@ -35,7 +35,7 @@ public abstract class Track implements
         Router,
         Connectable,
         LinkerCompartment,
-        Mapeable,
+        Mappable,
         LinkerCompartmentListener,
         Renderable {
     @JsonIgnore
@@ -50,10 +50,10 @@ public abstract class Track implements
     protected Track[] connections;
     @JsonIgnore
     List<Pair<Dir, Point>> connectedPositions = new ArrayList<>();
-    private final List<LinkerCompartmentListener> trackeableCompartmentListeners = new ArrayList<>();
+    private final List<LinkerCompartmentListener> trackableCompartmentListeners = new ArrayList<>();
 
     protected Track() {
-        trackeableCompartmentListeners.add(this);
+        trackableCompartmentListeners.add(this);
     }
 
     @Override
@@ -62,8 +62,8 @@ public abstract class Track implements
     }
 
     @JsonIgnore
-    public List<LinkerCompartmentListener> getTrackeableCompartmentListeners() {
-        return trackeableCompartmentListeners;
+    public List<LinkerCompartmentListener> getTrackableCompartmentListeners() {
+        return trackableCompartmentListeners;
     }
 
     public void setConnectedTracks(Track[] connectedTracks) {
@@ -207,7 +207,7 @@ public abstract class Track implements
     }
 
     /**************************************************************
-     * Mapeable implementation
+     * Mappable implementation
      ***************************************************************/
     @Override
     public Point getPosition() {
@@ -232,8 +232,8 @@ public abstract class Track implements
     }
 
     @Override
-    public boolean enterLinkerFromDir(Dir d, Linker vehicle) {
-        return getTrackDirector().enterLinkerFromDir(this, d, vehicle);
+    public boolean enterLinkerFromDir(Dir dir, Linker vehicle) {
+        return getTrackDirector().enterLinkerFromDir(this, dir, vehicle);
     }
 
     @Override
@@ -256,25 +256,25 @@ public abstract class Track implements
 
     @Override
     public void addLinkerCompartmentListener(LinkerCompartmentListener listener) {
-        trackeableCompartmentListeners.add(listener);
+        trackableCompartmentListeners.add(listener);
     }
 
     @Override
     public void removeLinkerCompartmentListener(LinkerCompartmentListener listener) {
-        trackeableCompartmentListeners.remove(listener);
+        trackableCompartmentListeners.remove(listener);
     }
 
     /**************************************************************
      * LinkerCompartmentListener implementation
      ***************************************************************/
     @Override
-    public boolean canEnter(Dir d, Linker v) {
-        return getTrackDirector().canEnter(this, d, v);
+    public boolean canEnter(Dir dir, Linker v) {
+        return getTrackDirector().canEnter(this, dir, v);
     }
 
     @Override
-    public boolean canExit(Dir d) {
-        return getTrackDirector().canExit(this, d);
+    public boolean canExit(Dir dir) {
+        return getTrackDirector().canExit(this, dir);
     }
 
     public Sensor getSensor() {

--- a/src/main/java/letrain/track/TrackDirector.java
+++ b/src/main/java/letrain/track/TrackDirector.java
@@ -22,22 +22,22 @@ public class TrackDirector<T extends Track> {
 
     private static final Logger log = LoggerFactory.getLogger(TrackDirector.class);
 
-    public boolean enterLinkerFromDir(T track, Dir d, Linker vehicle) {
-        if (!track.canEnter(d, vehicle)) {
-            log.debug("Cannot enter linker {} from {} into track {}: occupied or reserved.", vehicle, d,
+    public boolean enterLinkerFromDir(T track, Dir dir, Linker vehicle) {
+        if (!track.canEnter(dir, vehicle)) {
+            log.debug("Cannot enter linker {} from {} into track {}: occupied or reserved.", vehicle, dir,
                     track.getPosition());
             return false;
         }
 
         vehicle.setTrack(track);
         vehicle.setPosition(track.getPosition());
-        vehicle.setEntryDir(d);
-        Dir exitDir = track.getRouter().getDir(d);
+        vehicle.setEntryDir(dir);
+        Dir exitDir = track.getRouter().getDir(dir);
         if (exitDir != null) {
             vehicle.setDir(exitDir);
         } else {
             log.error("No exit direction found for track at {} entering from {}. Keeping current vehicle dir: {}.",
-                    track.getPosition(), d, vehicle.getDir());
+                    track.getPosition(), dir, vehicle.getDir());
         }
         track.setLinker(vehicle);
         return true;
@@ -52,7 +52,7 @@ public class TrackDirector<T extends Track> {
         return ret;
     }
 
-    public boolean canEnter(T track, Dir d, Linker v) {
+    public boolean canEnter(T track, Dir dir, Linker v) {
         // Points 5 & 10: One vehicle per track
         if (track.getLinker() != null) {
             return false;
@@ -68,11 +68,11 @@ public class TrackDirector<T extends Track> {
         return true;
     }
 
-    public boolean canExit(T track, Dir d) {
+    public boolean canExit(T track, Dir dir) {
         if (track.getLinker() != null) {
             Dir exitDir = track.getRouter().getDir(track.getLinker().getDir());
-            T target = (T) track.getConnected(d);
-            return target != null && target.canEnter(d, track.getLinker());
+            T target = (T) track.getConnected(dir);
+            return target != null && target.canEnter(dir, track.getLinker());
         }
         return true; // Qué contestar si estaba vacío??
     }

--- a/src/main/java/letrain/track/Trackable.java
+++ b/src/main/java/letrain/track/Trackable.java
@@ -1,6 +1,6 @@
 package letrain.track;
 
-public interface Trackeable {
+public interface Trackable {
     void setTrack(Track track);
 
     Track getTrack();

--- a/src/main/java/letrain/utils/PathGeometry.java
+++ b/src/main/java/letrain/utils/PathGeometry.java
@@ -9,18 +9,18 @@ import letrain.track.Track;
  */
 public class PathGeometry {
 
-    public static float getDirX(Dir d) {
-        if (d == null) return 0;
-        switch (d) {
+    public static float getDirX(Dir dir) {
+        if (dir == null) return 0;
+        switch (dir) {
             case E: case NE: case SE: return 0.5f;
             case W: case NW: case SW: return -0.5f;
             default: return 0;
         }
     }
 
-    public static float getDirZ(Dir d) {
-        if (d == null) return 0;
-        switch (d) {
+    public static float getDirZ(Dir dir) {
+        if (dir == null) return 0;
+        switch (dir) {
             case S: case SE: case SW: return 0.5f;
             case N: case NE: case NW: return -0.5f;
             default: return 0;

--- a/src/main/java/letrain/utils/SplinePath.java
+++ b/src/main/java/letrain/utils/SplinePath.java
@@ -36,8 +36,8 @@ public class SplinePath {
             Point first = points.get(0);
             Point last = points.get(points.size() - 1);
             vPoints.add(new Vector3(first.getX(), 0, first.getY())); // p0
-            for (Point p : points) {
-                vPoints.add(new Vector3(p.getX(), 0, p.getY()));
+            for (Point point : points) {
+                vPoints.add(new Vector3(point.getX(), 0, point.getY()));
             }
             vPoints.add(new Vector3(last.getX(), 0, last.getY())); // pn+1
         }

--- a/src/main/java/letrain/vehicle/Vehicle.java
+++ b/src/main/java/letrain/vehicle/Vehicle.java
@@ -2,25 +2,24 @@ package letrain.vehicle;
 
 import java.io.Serializable;
 
-import letrain.map.Dir;
-import letrain.map.Mapeable;
-import letrain.map.Point;
-import letrain.map.Reversible;
-import letrain.map.Rotable;
-import letrain.track.Track;
-import letrain.visitor.Renderable;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import letrain.map.Dir;
+import letrain.map.Mappable;
+import letrain.map.Point;
+import letrain.map.Reversible;
+import letrain.map.Rotatable;
+import letrain.track.Track;
+import letrain.visitor.Renderable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class Vehicle<T extends Track>
         implements
         Serializable,
-        Rotable,
+        Rotatable,
         Reversible,
         Selectable,
-        Mapeable,
+        Mappable,
         Transportable,
         Renderable,
         Destructible {
@@ -42,7 +41,7 @@ public abstract class Vehicle<T extends Track>
     };
 
     /***********************************************************
-     * Mapeable implementation
+     * Mappable implementation
      **********************************************************/
     public Point getPosition() {
         return pos;
@@ -78,7 +77,7 @@ public abstract class Vehicle<T extends Track>
     }
 
     /***********************************************************
-     * Rotable implementation
+     * Rotatable implementation
      **********************************************************/
     @Override
     public void rotateLeft() {

--- a/src/main/java/letrain/vehicle/impl/RailIterator.java
+++ b/src/main/java/letrain/vehicle/impl/RailIterator.java
@@ -1,16 +1,16 @@
 package letrain.vehicle.impl;
 
 import letrain.map.Dir;
-import letrain.map.Mapeable;
+import letrain.map.Mappable;
 import letrain.map.Point;
-import letrain.map.Rotable;
+import letrain.map.Rotatable;
 import letrain.track.Track;
-import letrain.track.Trackeable;
+import letrain.track.Trackable;
 import letrain.vehicle.Transportable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RailIterator implements Transportable, Trackeable, Rotable, Mapeable {
+public class RailIterator implements Transportable, Trackable, Rotatable, Mappable {
     Logger log = LoggerFactory.getLogger(RailIterator.class);
     Point position;
     Dir dir;
@@ -41,9 +41,11 @@ public class RailIterator implements Transportable, Trackeable, Rotable, Mapeabl
         Dir nextExitDir = (entryPort != null) ? nextTrack.getDir(entryPort) : null;
 
         if (nextExitDir == null) {
-            // Fallback: If the track router doesn't have a route for this entry port (kink),
+            // Fallback: If the track router doesn't have a route for this entry port
+            // (kink),
             // keep moving in the same direction. This matches TrackDirector's behavior.
-            log.warn("Kink or missing route detected at {}. Entry port {} not found in router. Falling back to movement dir {}.",
+            log.warn(
+                    "Kink or missing route detected at {}. Entry port {} not found in router. Falling back to movement dir {}.",
                     nextTrack.getPosition(), entryPort, movementDir);
             nextExitDir = movementDir;
         }

--- a/src/main/java/letrain/vehicle/impl/Tracker.java
+++ b/src/main/java/letrain/vehicle/impl/Tracker.java
@@ -2,12 +2,12 @@ package letrain.vehicle.impl;
 
 import letrain.map.Dir;
 import letrain.track.Track;
-import letrain.track.Trackeable;
+import letrain.track.Trackable;
 import letrain.vehicle.Vehicle;
 
 public abstract class Tracker
         extends Vehicle
-        implements Trackeable {
+        implements Trackable {
     Track track;
 
     @Override

--- a/src/main/java/letrain/visitor/Visitor.java
+++ b/src/main/java/letrain/visitor/Visitor.java
@@ -41,7 +41,7 @@ public interface Visitor {
 
     void visitSemaphore(RailSemaphore semaphore);
 
-    void visitStation(Station Station);
+    void visitStation(Station station);
 
     void visitGroundMap(GroundMap groundMap);
 

--- a/src/main/java/letrain/visitor/gdx3d/BaseSubRenderer.java
+++ b/src/main/java/letrain/visitor/gdx3d/BaseSubRenderer.java
@@ -1,6 +1,7 @@
 package letrain.visitor.gdx3d;
 
 import java.util.List;
+
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import letrain.mvp.Model;
@@ -73,7 +74,7 @@ public abstract class BaseSubRenderer implements Visitor {
     @Override public void visitCursor(letrain.vehicle.impl.Cursor cursor) {}
     @Override public void visitSensor(letrain.track.Sensor sensor) {}
     @Override public void visitSemaphore(letrain.track.RailSemaphore semaphore) {}
-    @Override public void visitStation(letrain.track.Station Station) {}
+    @Override public void visitStation(letrain.track.Station station) {}
     @Override public void visitGroundMap(letrain.ground.GroundMap groundMap) {}
     @Override public void visitGround(letrain.ground.Ground ground) {}
     @Override public void visitBridgeGateRailTrack(letrain.track.rail.BridgeGateRailTrack bridgeGateRailTrack) {}

--- a/src/main/java/letrain/visitor/gdx3d/InfrastructureRenderer.java
+++ b/src/main/java/letrain/visitor/gdx3d/InfrastructureRenderer.java
@@ -1,7 +1,7 @@
 package letrain.visitor.gdx3d;
 
 import java.util.List;
-import letrain.visitor.Visitor;
+
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.math.Vector3;
@@ -12,8 +12,8 @@ import letrain.track.RailSemaphore;
 import letrain.track.Sensor;
 import letrain.track.Station;
 import letrain.track.rail.ForkRailTrack;
-import letrain.utils.PathGeometry;
 import letrain.utils.Pair;
+import letrain.utils.PathGeometry;
 
 public class InfrastructureRenderer extends BaseSubRenderer {
     private final TrackRenderer trackRenderer;
@@ -110,12 +110,12 @@ public class InfrastructureRenderer extends BaseSubRenderer {
 
         float x = sensor.getPosition().getX();
         float y = sensor.getPosition().getY();
-        Dir d = sensor.getCreationDir();
-        if (d == null)
-            d = Dir.N;
+        Dir dir = sensor.getCreationDir();
+        if (dir == null)
+            dir = Dir.N;
 
-        float dx = PathGeometry.getDirX(d);
-        float dz = PathGeometry.getDirZ(d);
+        float dx = PathGeometry.getDirX(dir);
+        float dz = PathGeometry.getDirZ(dir);
         float angle = (float) Math.atan2(dx, dz) * com.badlogic.gdx.math.MathUtils.radiansToDegrees;
 
         ModelInstance instance = resourceContext.getModelInstance(resourceContext.sensorModel);
@@ -153,9 +153,9 @@ public class InfrastructureRenderer extends BaseSubRenderer {
             if (track != null && track instanceof letrain.track.rail.RailTrack) {
                 letrain.track.rail.RailTrack railTrack = (letrain.track.rail.RailTrack) track;
                 if (railTrack.getNumRoutes() > 0) {
-                    Dir d = railTrack.getFirstOpenDir();
-                    float dx = PathGeometry.getDirX(d);
-                    float dz = PathGeometry.getDirZ(d);
+                    Dir dir = railTrack.getFirstOpenDir();
+                    float dx = PathGeometry.getDirX(dir);
+                    float dz = PathGeometry.getDirZ(dir);
                     offsetX = dz * 1.0f;
                     offsetZ = -dx * 1.0f;
                     angle = (float) Math.atan2(dx, dz) * com.badlogic.gdx.math.MathUtils.radiansToDegrees;
@@ -364,10 +364,10 @@ public class InfrastructureRenderer extends BaseSubRenderer {
                 break;
         }
 
-        Dir d = cursor.getDir();
+        Dir dir = cursor.getDir();
         Point pos = cursor.getPosition();
-        float dx = PathGeometry.getDirX(d);
-        float dz = PathGeometry.getDirZ(d);
+        float dx = PathGeometry.getDirX(dir);
+        float dz = PathGeometry.getDirZ(dir);
         float angle = (float) Math.atan2(dx, dz) * com.badlogic.gdx.math.MathUtils.radiansToDegrees;
 
         ModelInstance instance = resourceContext.getModelInstance(resourceContext.cursorModel);

--- a/src/main/java/letrain/visitor/gdx3d/TrackRenderer.java
+++ b/src/main/java/letrain/visitor/gdx3d/TrackRenderer.java
@@ -1,17 +1,17 @@
 package letrain.visitor.gdx3d;
 
 import java.util.List;
+
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
-import letrain.visitor.Visitor;
 import com.badlogic.gdx.math.Vector3;
+import letrain.ground.GroundMap;
 import letrain.map.Dir;
 import letrain.map.Point;
-import letrain.track.rail.RailTrack;
-import letrain.track.rail.TunnelRailTrack;
 import letrain.track.rail.BridgeGateRailTrack;
 import letrain.track.rail.BridgeRailTrack;
+import letrain.track.rail.RailTrack;
+import letrain.track.rail.TunnelRailTrack;
 import letrain.utils.PathGeometry;
-import letrain.ground.GroundMap;
 
 public class TrackRenderer extends BaseSubRenderer {
 
@@ -63,9 +63,9 @@ public class TrackRenderer extends BaseSubRenderer {
         }
 
         if (track.getNumRoutes() == 0) {
-            Dir d = getValidOrientation(track);
-            if (d != null) {
-                drawHalfTrack(track.getPosition(), d, true, 1.0f, 1.0f);
+            Dir dir = getValidOrientation(track);
+            if (dir != null) {
+                drawHalfTrack(track.getPosition(), dir, true, 1.0f, 1.0f);
             }
         }
     }
@@ -85,14 +85,14 @@ public class TrackRenderer extends BaseSubRenderer {
         visitRailTrack(bridgeRailTrack);
     }
 
-    public void drawHalfTrack(Point pos, Dir d, boolean connected, float shortenL, float shortenR) {
-        drawHalfTrackElevated(pos, d, connected, 0.0f, shortenL, shortenR, resourceContext.railModel);
+    public void drawHalfTrack(Point pos, Dir dir, boolean connected, float shortenL, float shortenR) {
+        drawHalfTrackElevated(pos, dir, connected, 0.0f, shortenL, shortenR, resourceContext.railModel);
     }
 
-    public void drawHalfTrackElevated(Point pos, Dir d, boolean connected, float elevation,
+    public void drawHalfTrackElevated(Point pos, Dir dir, boolean connected, float elevation,
             float shortenL, float shortenR, com.badlogic.gdx.graphics.g3d.Model railModelToUse) {
-        float dx = PathGeometry.getDirX(d);
-        float dz = PathGeometry.getDirZ(d);
+        float dx = PathGeometry.getDirX(dir);
+        float dz = PathGeometry.getDirZ(dir);
         renderSegment(pos, new Vector3(0, 0, 0), new Vector3(dx, 0, dz), 
                 connected, elevation, shortenL, shortenR, railModelToUse);
     }

--- a/src/main/java/letrain/visitor/terminal/InfoVisitor.java
+++ b/src/main/java/letrain/visitor/terminal/InfoVisitor.java
@@ -1,7 +1,6 @@
 package letrain.visitor.terminal;
 
 import com.googlecode.lanterna.TextColor;
-import letrain.visitor.Visitor;
 import com.googlecode.lanterna.TextColor.ANSI;
 import letrain.economy.EconomyManager;
 import letrain.ground.Ground;
@@ -25,6 +24,7 @@ import letrain.track.rail.TunnelRailTrack;
 import letrain.vehicle.impl.Cursor;
 import letrain.vehicle.impl.rail.Locomotive;
 import letrain.vehicle.impl.rail.Wagon;
+import letrain.visitor.Visitor;
 
 public class InfoVisitor implements Visitor {
 
@@ -167,10 +167,10 @@ public class InfoVisitor implements Visitor {
 
     private String getTrackConnectionsAspect(RailTrack track) {
         StringBuffer ret = new StringBuffer();
-        for (Dir d : Dir.values()) {
-            Track connected = track.getConnected(d);
+        for (Dir dir : Dir.values()) {
+            Track connected = track.getConnected(dir);
             if (connected != null) {
-                ret.append("(" + d + "->" + connected + ")");
+                ret.append("(" + dir + "->" + connected + ")");
             }
         }
         return ret.toString();
@@ -227,8 +227,8 @@ public class InfoVisitor implements Visitor {
     }
 
     @Override
-    public void visitStation(Station Station) {
-        infoBarText += "Station:[" + Station.getId() + "]" + "\n" + "Position:" + Station.getPosition() + "\n";
+    public void visitStation(Station station) {
+        infoBarText += "Station:[" + station.getId() + "]" + "\n" + "Position:" + station.getPosition() + "\n";
     }
 
     @Override

--- a/src/test/java/letrain/map/DirTest.java
+++ b/src/test/java/letrain/map/DirTest.java
@@ -210,8 +210,8 @@ class DirTest {
             "SE, false"
     })
     void testIsStraight(Dir a, boolean b) {
-        Dir d = Dir.E;
-        Assertions.assertEquals(b, d.isStraight(a));
+        Dir dir = Dir.E;
+        Assertions.assertEquals(b, dir.isStraight(a));
         Assertions.assertTrue(a.isStraight(a.inverse()));
     }
 

--- a/src/test/java/letrain/map/TestCircuit1Trait.java
+++ b/src/test/java/letrain/map/TestCircuit1Trait.java
@@ -59,7 +59,7 @@ class TestCircuit1TraitTest {
 
     private boolean makeTrack() {
         Point cursorPosition = cursor.getPosition();
-        Dir dir = cursor.getDir();
+        Dir cursorDir = cursor.getDir();
         if (oldTrack != null) {
             oldDir = cursorPosition.locate(oldTrack.getPosition());
         } else {
@@ -78,14 +78,11 @@ class TestCircuit1TraitTest {
                 return false;
             }
         }
-        track.addRoute(oldDir, dir);
-        track.setPosition(cursorPosition);
-        if (oldTrack != null) {
-            track.connect(oldDir, oldTrack);
-            oldTrack.connect(track.getDir(dir).inverse(), track);
-        }
-        railMap.addTrack(cursorPosition, track);
-        if (canBeAFork(track, oldDir, dir)) {
+        track.addRoute(oldDir, cursorDir);
+
+            oldTrack.connect(track.getDir(cursorDir).inverse(), track);
+
+        if (canBeAFork(track, oldDir, cursorDir)) {
             final ForkRailTrack myNewTrack = new ForkRailTrack(1);
             // Modmodel.addFork(myNewTrack)
             final Router router = track.getRouter();

--- a/src/test/java/letrain/map/TestCircuit1Trait.java
+++ b/src/test/java/letrain/map/TestCircuit1Trait.java
@@ -96,9 +96,9 @@ class TestCircuit1TraitTest {
             myNewTrack.setNormalRoute();
             railMap.removeTrack(track.getPosition());
             railMap.addTrack(cursor.getPosition(), myNewTrack);
-            for (Dir d : Dir.values()) {
-                if (track.getConnected(d) != null) {
-                    myNewTrack.connect(d, track.getConnected(d));
+            for (Dir dir : Dir.values()) {
+                if (track.getConnected(dir) != null) {
+                    myNewTrack.connect(dir, track.getConnected(dir));
                 }
             }
             myNewTrack.setAlternativeRoute();

--- a/src/test/java/letrain/vehicle/impl/rail/TrainMoveLinkersTest.java
+++ b/src/test/java/letrain/vehicle/impl/rail/TrainMoveLinkersTest.java
@@ -15,13 +15,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import letrain.map.Dir;
 import letrain.map.Point;
 import letrain.track.Track;
 import letrain.vehicle.impl.Linker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 @DisplayName("Train.moveLinkers() — NPE fix regression tests")
 class TrainMoveLinkersTest {
@@ -369,7 +368,7 @@ class TrainMoveLinkersTest {
             Linker linker) {
 
         doAnswer(inv -> {
-            Dir d = inv.getArgument(0);
+            Dir dir = inv.getArgument(0);
             Linker v = inv.getArgument(1);
             linkerTrackRef.set(targetTrack);
             targetTrackLinkerRef.set(v);


### PR DESCRIPTION
## Summary
Renombra interfaces con errores ortográficos y corrige nombres de parámetros.

| Cambio | Archivos |
|--------|----------|
| `Trackeable` → `Trackable` | 3 archivos |
| `Mapeable` → `Mappable` | 6 archivos |
| `Rotable` → `Rotatable` | 4 archivos |
| `Station Station` → `Station station` | Visitor, Model, InfoVisitor |
| `Dir d`/`Linker v` → nombres descriptivos | Interfaces LinkerCompartment, TrackDirector |

## Verification
```
mvn clean test → BUILD SUCCESS
```

Closes #85