### PR TITLE
fix: force compass letters to always render white

### DIFF
--- a/src/main/java/letrain/mvp/impl/graphic/GraphicPresenter.java
+++ b/src/main/java/letrain/mvp/impl/graphic/GraphicPresenter.java
@@ -906,7 +906,8 @@ public class GraphicPresenter extends ApplicationAdapter
         com.badlogic.gdx.graphics.g3d.decals.Decal d = getGlyphDecal(text.charAt(0));
         if (d != null) {
             d.setPosition(x, y, z);
-            d.setScale(0.4f); 
+            d.setScale(0.4f);
+            d.setColor(com.badlogic.gdx.graphics.Color.WHITE);
             // Flat on the compass floor, North is -Z
             d.lookAt(new com.badlogic.gdx.math.Vector3(x, y + 1, z), new com.badlogic.gdx.math.Vector3(0, 0, -1));
             decalBatch.add(d);


### PR DESCRIPTION
## Summary
Las letras de la brújula (N, S, E, W) a veces se mostraban en negro porque los decals del pool conservaban el color del uso anterior. Se fuerza `setColor(Color.WHITE)` al añadir cada decal.

## Fix
1 línea en `addCompassDecal()`:
```java
d.setColor(com.badlogic.gdx.graphics.Color.WHITE);
```

## Verification
```
mvn clean compile → BUILD SUCCESS
```