### PR TITLE
fix: prevent infinite loops when walking track circuits

### DIFF
--- a/src/main/java/letrain/core/segments/impl/TopologyServiceImpl.java
+++ b/src/main/java/letrain/core/segments/impl/TopologyServiceImpl.java
@@ -105,10 +105,15 @@ public class TopologyServiceImpl implements TopologyService {
 
     private CrawlResult crawl(RailTrack startTrack, Dir startDir, Map<RailTrack, RailNodeImpl> trackToNode) {
         List<RailTrack> visited = new ArrayList<>();
+        java.util.Set<RailTrack> seen = new java.util.HashSet<>();
         RailTrack currentTrack = (RailTrack) startTrack.getConnected(startDir);
         Dir incomingDir = startDir.inverse();
 
         while (currentTrack != null && !trackToNode.containsKey(currentTrack)) {
+            if (!seen.add(currentTrack)) {
+                // Cycle detected — circuit with no fork nodes. Break to avoid infinite loop.
+                return null;
+            }
             visited.add(currentTrack);
             Dir nextDir = currentTrack.getDir(incomingDir);
             if (nextDir == null) return null;

--- a/src/main/java/letrain/vehicle/impl/rail/TrainSafetyManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainSafetyManager.java
@@ -159,7 +159,8 @@ public class TrainSafetyManager {
         
         if (nextSteps == null || nextSteps.isEmpty()) {
             RailIterator it = new RailIterator(headTrack, exitDir);
-            while (it.advance()) {
+            int maxIterations = 10000; // Safety guard against infinite loops on circuits
+            while (it.advance() && maxIterations-- > 0) {
                 Track t = it.getTrack();
                 Segment nextS = graph.getSegment((RailTrack) t);
                 if (nextS != null && !nextS.equals(s)) return nextS;


### PR DESCRIPTION
## Summary
Arregla dos bucles infinitos que congelaban el juego al añadir vías a un circuito cerrado sin forks mientras un tren circulaba.

## Causa
Ambos métodos caminan por las vías siguiendo conexiones, pero ninguno detectaba ciclos:

| Método | Fix |
|--------|-----|
| `TopologyServiceImpl.crawl()` | Añadido `HashSet` para detectar tracks ya visitados |
| `TrainSafetyManager.findNextSegmentTopological()` | Añadido límite de 10000 iteraciones |

## Verification
```
mvn clean test → BUILD SUCCESS
Tests run: 266, Failures: 0
```

Closes #105