### PR TITLE
fix: clear fork locks when topology is rebuilt

### DIFF
--- a/src/main/java/letrain/core/segments/impl/BlockManagerImpl.java
+++ b/src/main/java/letrain/core/segments/impl/BlockManagerImpl.java
@@ -158,6 +158,13 @@ public class BlockManagerImpl implements BlockManager {
     public void clearAll() {
         segmentOwners.clear();
         trainSegments.clear();
+        // Release all fork locks when topology is rebuilt
+        for (letrain.core.segments.RailNode node : forkOwnershipCounts.keySet()) {
+            if (node.getTrack() instanceof letrain.track.rail.ForkRailTrack) {
+                ((letrain.track.rail.ForkRailTrack) node.getTrack()).setLocked(false);
+            }
+        }
+        forkOwnershipCounts.clear();
     }
 
     private void registerTrainSegment(Train train, Segment segment) {


### PR DESCRIPTION
## Summary
Los forks añadidos durante la edición de vías se quedaban bloqueados permanentemente. `BlockManagerImpl.clearAll()` no limpiaba `forkOwnershipCounts` ni reseteaba los forks.

## Fix
`clearAll()` ahora:
1. Limpia `forkOwnershipCounts`
2. Pone `setLocked(false)` en todos los forks conocidos

Esto se ejecuta al cambiar de modo RAILS después de editar (tabula rasa).

## Verification
```
mvn clean test → BUILD SUCCESS
Tests run: 266, Failures: 0
```

Closes #107