### PR TITLE
fix: getLinkDir walks through same-train linkers to enable linking on curves

### DIFF
--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -997,6 +997,25 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
         if (adjacentLinker != null && adjacentLinker.getTrain() != this) {
             return linkerDir;
         }
+        // If the adjacent linker belongs to the same train, walk through
+        // the train's linkers following track directions to find the exit
+        // where a different train might be. This handles multi-linker
+        // trains where the end linker points toward the train center.
+        if (adjacentLinker != null && adjacentLinker.getTrain() == this) {
+            Track currentTrack = linker.getTrack().getConnected(linkerDir);
+            Linker nextLinker = adjacentLinker;
+            while (currentTrack != null && nextLinker != null && nextLinker.getTrain() == this) {
+                Dir nextDir = currentTrack.getDir(nextLinker.getDir());
+                if (nextDir == null) break;
+                Track nextTrack = currentTrack.getConnected(nextDir);
+                if (nextTrack == null) break;
+                currentTrack = nextTrack;
+                nextLinker = currentTrack.getLinker();
+            }
+            if (nextLinker != null && nextLinker.getTrain() != this) {
+                return linkerDir;
+            }
+        }
         return null;
     }
 


### PR DESCRIPTION
## Summary
El linking en curvas fallaba porque `getLinkDir()` solo miraba el primer linker adyacente. En trenes multi-linker, el último vagón apunta hacia el centro del tren, así que el primer linker adyacente es del mismo tren → `getLinkDir` devolvía `null`.

## Fix
Ahora `getLinkDir()` recorre la cadena de linkers del mismo tren siguiendo las direcciones del router hasta encontrar un linker de otro tren (o salir del tren).

```
Antes: [Wagon A] → [Loco A] → mismo tren → null ❌
Ahora: [Wagon A] → [Loco A] → [Wagon B] → otro tren → dir ✅
```

## Verification
```
mvn clean test → BUILD SUCCESS
Tests run: 266, Failures: 0
```

Closes #111