### PR TITLE
fix: backward link usa conexiones físicas en vez de entryDir

### DIFF
--- a/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
@@ -75,6 +75,13 @@ public class TrainCouplingManager {
         joined = false;
         Linker lastLinker = null;
         Dir dir = Dir.E;
+
+        if (train.getLinkers().size() == 1) {
+            lastLinker = (Linker) train.getDirectorLinker();
+            Dir entryDir = lastLinker.getEntryDir();
+            if (entryDir == null) {
+                entryDir = lastLinker.getRealDir().inverse();
+            }
             if (forwardDirection) {
                 linkerJoinSense = Train.LinkersSense.FRONT;
                 dir = lastLinker.getTrack().getDir(entryDir);
@@ -86,8 +93,7 @@ public class TrainCouplingManager {
             if (forwardDirection) {
                 lastLinker = train.getLinkers().getFirst();
                 linkerJoinSense = Train.LinkersSense.FRONT;
-                dir = ((Locomotive) train.getDirectorLinker()).getTrack()
-                        .getDir(((Locomotive) train.getDirectorLinker()).getEntryDir());
+                dir = getLinkDir(lastLinker);
             } else {
                 lastLinker = train.getLinkers().getLast();
                 linkerJoinSense = Train.LinkersSense.BACK;

--- a/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
@@ -98,7 +98,19 @@ public class TrainCouplingManager {
             } else {
                 lastLinker = train.getLinkers().getLast();
                 linkerJoinSense = Train.LinkersSense.BACK;
-                dir = lastLinker.getEntryDir();
+                // Find the connection from the last linker that leads away
+                // from our own train (empty track or different train).
+                Track lastTrack = lastLinker.getTrack();
+                dir = null;
+                for (Dir conn : lastTrack.getConnections()) {
+                    Track connected = lastTrack.getConnected(conn);
+                    if (connected == null) continue;
+                    Linker l = connected.getLinker();
+                    if (l == null || l.getTrain() != train) {
+                        dir = conn;
+                        break;
+                    }
+                }
             }
         }
         if (lastLinker != null && lastLinker.getTrack() != null && dir != null) {

--- a/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
@@ -75,13 +75,6 @@ public class TrainCouplingManager {
         joined = false;
         Linker lastLinker = null;
         Dir dir = Dir.E;
-
-        if (train.getLinkers().size() == 1) {
-            lastLinker = (Linker) train.getDirectorLinker();
-            Dir entryDir = lastLinker.getEntryDir();
-            if (entryDir == null) {
-                entryDir = lastLinker.getRealDir().inverse();
-            }
             if (forwardDirection) {
                 linkerJoinSense = Train.LinkersSense.FRONT;
                 dir = lastLinker.getTrack().getDir(entryDir);


### PR DESCRIPTION
## Fix
Para backward multi-linker, el `entryDir` del último vagón depende de hacia dónde mira la loco. Se reemplaza por iteración sobre las conexiones físicas del track, eligiendo la que lleva a un track sin linker del mismo tren.

También: forward multi-linker restaura `getLinkDir` con walk-through, y el bucle de recolección salta linkers del mismo tren.

Closes #116