### PR TITLE
debug: log why rebind finds no segments for tracks

### DIFF
--- a/src/main/java/letrain/core/segments/impl/TopologyServiceImpl.java
+++ b/src/main/java/letrain/core/segments/impl/TopologyServiceImpl.java
@@ -111,7 +111,12 @@ public class TopologyServiceImpl implements TopologyService {
 
         while (currentTrack != null && !trackToNode.containsKey(currentTrack)) {
             if (!seen.add(currentTrack)) {
-                // Cycle detected — circuit with no fork nodes. Break to avoid infinite loop.
+                // Cycle detected — circuit with no intermediate fork nodes.
+                // The entire loop forms one segment from start node back to itself.
+                RailNodeImpl startNode = trackToNode.get(startTrack);
+                if (startNode != null) {
+                    return new CrawlResult(startNode, incomingDir, visited);
+                }
                 return null;
             }
             visited.add(currentTrack);

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -288,9 +288,12 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                 letrain.core.segments.Segment segment = graph.getSegment((letrain.track.rail.RailTrack) linker.getTrack());
                 if (segment != null) {
                     segmentsToClaim.add(segment);
+                } else {
+                    log.warn("Train {} rebind: no segment for track {} (linker {})", id, linker.getTrack().getPosition(), linker);
                 }
+            } else {
+                log.warn("Train {} rebind: linker {} track is not RailTrack: {}", id, linker, linker.getTrack());
             }
-        }
 
         for (letrain.core.segments.Segment segment : segmentsToClaim) {
             if (!blockManager.tryLock(this, segment)) {

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -294,7 +294,9 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
             } else {
                 log.warn("Train {} rebind: linker {} track is not RailTrack: {}", id, linker, linker.getTrack());
             }
+        }
 
+        // Lock the segments we found
         for (letrain.core.segments.Segment segment : segmentsToClaim) {
             if (!blockManager.tryLock(this, segment)) {
                 // Si falla el bloqueo normal tras una Tabula Rasa, es que hay convivencia forzada

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -288,11 +288,7 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
                 letrain.core.segments.Segment segment = graph.getSegment((letrain.track.rail.RailTrack) linker.getTrack());
                 if (segment != null) {
                     segmentsToClaim.add(segment);
-                } else {
-                    log.warn("Train {} rebind: no segment for track {} (linker {})", id, linker.getTrack().getPosition(), linker);
                 }
-            } else {
-                log.warn("Train {} rebind: linker {} track is not RailTrack: {}", id, linker, linker.getTrack());
             }
         }
 

--- a/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
@@ -76,12 +76,6 @@ public class TrainCouplingManager {
         Linker lastLinker = null;
         Dir dir = Dir.E;
 
-        log.info("[LINK] === start forward={} trainSize={} ===", forwardDirection, train.getLinkers().size());
-        for (Linker l : train.getLinkers()) {
-            log.info("[LINK]   linker={} pos={} dir={} entryDir={} track={}",
-                    l, l.getPosition(), l.getDir(), l.getEntryDir(), l.getTrack() != null ? l.getTrack().getPosition() : null);
-        }
-
         if (train.getLinkers().size() == 1) {
             lastLinker = (Linker) train.getDirectorLinker();
             Dir entryDir = lastLinker.getEntryDir();
@@ -120,8 +114,6 @@ public class TrainCouplingManager {
         }
         if (lastLinker != null && lastLinker.getTrack() != null && dir != null) {
             Track nextTrack = lastLinker.getTrack().getConnected(dir);
-            log.info("[LINK] lastLinker={} dir={} nextTrack={}", lastLinker, dir,
-                    nextTrack != null ? nextTrack.getPosition() : null);
             if (nextTrack != null) {
                 RailIterator iterator = new RailIterator(nextTrack, dir);
                 // Fix initial direction for curves: find actual exit from nextTrack
@@ -142,23 +134,18 @@ public class TrainCouplingManager {
                 Linker nextLinker = iterator.getTrack().getLinker();
                 // Skip linkers belonging to our own train
                 while (nextLinker != null && nextLinker.getTrain() == train) {
-                    log.info("[LINK]   skipping same-train {} at {}", nextLinker, nextLinker.getPosition());
                     if (!iterator.advance()) break;
                     nextLinker = iterator.getTrack().getLinker();
                 }
-                log.info("[LINK]   after skip: nextLinker={}", nextLinker);
                 if (nextLinker != null && train != nextLinker.getTrain()) {
                     while (nextLinker != null) {
                         if (nextLinker.getTrain() != train) {
                             linkersToJoin.add(nextLinker);
-                            log.info("[LINK]   added {}", nextLinker);
                         }
                         if (!iterator.advance()) {
-                            log.info("[LINK]   advance=false, done");
                             break;
                         }
                         nextLinker = iterator.getTrack().getLinker();
-                        log.info("[LINK]   next after advance: {}", nextLinker);
                     }
                 }
             }
@@ -406,9 +393,6 @@ public class TrainCouplingManager {
     Dir getLinkDir(Linker linker) {
         Dir linkerDir = linker.getDir();
         Linker adjacentLinker = getAdjacentLinker(linker, linkerDir);
-        log.info("[GETLINKDIR] linker={} pos={} dir={} adjacent={} adjTrain={}",
-                linker, linker.getPosition(), linkerDir, adjacentLinker,
-                adjacentLinker != null ? adjacentLinker.getTrain() : null);
         if (adjacentLinker != null && adjacentLinker.getTrain() != train) {
             return linkerDir;
         }


### PR DESCRIPTION
## Debug
Añade logs en `rebind()` para diagnosticar por qué `rebound to 0 segments`.

Cuando el tren nuevo no encuentra segmentos, se loguea:
- `no segment for track POS (linker LINKER)` — el grafo no tiene ese track
- `linker LINKER track is not RailTrack: TRACK` — el track no es RailTrack

Closes #118