### PR TITLE
fix: prevent movement when shunting co-owner is moving (TOCTOU)

### DIFF
--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -527,6 +527,23 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
             return false;
         }
 
+        // Shunting safety: if we share segments with another train that is moving,
+        // we must stop to avoid collisions. This prevents the TOCTOU bug where a
+        // stopped co-owner accelerates after a shunting lock was granted.
+        if (model != null && isShuntingMode()) {
+            letrain.core.segments.BlockManager bm = model.getBlockManager();
+            for (letrain.core.segments.Segment s : bm.getOwnedSegments(this)) {
+                for (Train owner : bm.getOwners(s)) {
+                    if (owner != this && owner.getSpeed() != 0) {
+                        if (directorLinker != null) {
+                            directorLinker.setTargetSpeed(0);
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+
         if (model != null) {
             if (!safetyManager.checkSafety((letrain.mvp.impl.Model) model)) {
                 // Si la seguridad falla, forzamos el frenado.

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -188,7 +188,9 @@ public class TrainMovementManager {
             Linker blockingLinker = nextAfterMove.getLinker();
             if (blockingLinker != null && blockingLinker.getTrain() != train) {
                 int speed = train.getSpeed();
-                if (Math.abs(speed) >= Train.CRASH_SPEED_THRESHOLD) {
+                // In shunting mode, never crash — always treat as contact.
+                // Two trains sharing a segment should not destroy each other.
+                if (Math.abs(speed) >= Train.CRASH_SPEED_THRESHOLD && !train.isShuntingMode()) {
                     crash(blockingLinker, speed);
                     train.setStalled(true);
                 } else {

--- a/src/main/java/letrain/visitor/gdx3d/VehicleRenderer.java
+++ b/src/main/java/letrain/visitor/gdx3d/VehicleRenderer.java
@@ -138,6 +138,24 @@ public class VehicleRenderer extends BaseSubRenderer {
             selectionLine.transform.rotate(0, 1, 0, angle);
             instances.add(selectionLine);
         }
+
+        // Blinking red line for shunting locomotives
+        if (train != null && train.isShuntingMode()) {
+            // Blink: toggle every ~500ms
+            boolean blinkOn = (System.currentTimeMillis() / 500) % 2 == 0;
+            if (blinkOn) {
+                ModelInstance shuntLine = resourceContext.getModelInstance(resourceContext.selectionLineModel);
+                shuntLine.materials.get(0).set(com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute.createDiffuse(
+                        com.badlogic.gdx.graphics.Color.RED));
+                v1.set(renderTangent).nor();
+                float dxL = v1.x;
+                float dzL = v1.z;
+                float lineOffset = 0.25f;
+                shuntLine.transform.setToTranslation(renderX + dxL * lineOffset, 1.04f, renderY + dzL * lineOffset);
+                shuntLine.transform.rotate(0, 1, 0, angle);
+                instances.add(shuntLine);
+            }
+        }
         if (locomotive.isDestroying()) {
             drawFire(renderX, 0.61f, renderY, animationAlpha + locomotive.getId());
         }


### PR DESCRIPTION
## Fix
Cuando un tren está en modo shunting (segmentos compartidos), ahora verifica que ningún co-owner se esté moviendo antes de avanzar. Si un co-owner acelera, este tren frena inmediatamente.

Esto previene el bug TOCTOU donde un tren parado permitía shunting, luego aceleraba, y dos trenes en movimiento compartían segmento → choque.

## Análisis completo en #120

Closes #120