### PR TITLE
fix: validate router direction against physical connection in enterLinkerFromDir

### DIFF
--- a/src/main/java/letrain/track/TrackDirector.java
+++ b/src/main/java/letrain/track/TrackDirector.java
@@ -33,11 +33,18 @@ public class TrackDirector<T extends Track> {
         vehicle.setPosition(track.getPosition());
         vehicle.setEntryDir(dir);
         Dir exitDir = track.getRouter().getDir(dir);
-        if (exitDir != null) {
+        if (exitDir != null && track.getConnected(exitDir) != null) {
             vehicle.setDir(exitDir);
         } else {
-            log.error("No exit direction found for track at {} entering from {}. Keeping current vehicle dir: {}.",
-                    track.getPosition(), dir, vehicle.getDir());
+            // Router gave invalid or unconnected direction — find actual
+            // physical exit (skip the entry port we came from).
+            Dir entryPort = dir.inverse();
+            for (Dir conn : track.getConnections()) {
+                if (conn != entryPort && track.getConnected(conn) != null) {
+                    vehicle.setDir(conn);
+                    break;
+                }
+            }
         }
         track.setLinker(vehicle);
         return true;

--- a/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
@@ -75,13 +75,9 @@ public class Locomotive extends Linker implements Tractor {
         }
         Dir currentDir = getDir();
         Dir currentEntry = getEntryDir();
-        Train.log.info("[TOGGLE] loco={} before: dir={} entryDir={} reversed={}",
-                id, currentDir, currentEntry, isReversed());
         setEntryDir(currentDir);
         setDir(currentEntry);
         setReversed(!isReversed());
-        Train.log.info("[TOGGLE] loco={} after:  dir={} entryDir={} reversed={}",
-                id, getDir(), getEntryDir(), isReversed());
         if (getTrain() != null) {
             getTrain().setStalled(false);
         }

--- a/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
@@ -317,8 +317,6 @@ public class Locomotive extends Linker implements Tractor {
 
     @Override
     public void setCurrentSpeed(int speed) {
-        Train.log.info("[SPEED] loco={} setCurrentSpeed {} (was {}) target={}",
-                id, speed, currentSpeed, targetSpeed);
         int effectiveSpeed = speed;
         if (getTrain() != null && getTrain().isShuntingMode()) {
             effectiveSpeed = Math.min(speed, SHUNTING_SPEED_LIMIT);

--- a/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
@@ -70,16 +70,18 @@ public class Locomotive extends Linker implements Tractor {
     @Override
     public void toggleReversed() {
         if (currentSpeed > 0) {
-            // No permitir invertir marcha en movimiento (opcional, pero realista)
-            // Por ahora solo ponemos targetSpeed a 0
             setTargetSpeed(0);
             return;
         }
         Dir currentDir = getDir();
         Dir currentEntry = getEntryDir();
+        log.info("[TOGGLE] loco={} before: dir={} entryDir={} reversed={}",
+                id, currentDir, currentEntry, isReversed());
         setEntryDir(currentDir);
         setDir(currentEntry);
         setReversed(!isReversed());
+        log.info("[TOGGLE] loco={} after:  dir={} entryDir={} reversed={}",
+                id, getDir(), getEntryDir(), isReversed());
         if (getTrain() != null) {
             getTrain().setStalled(false);
         }

--- a/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
@@ -75,12 +75,12 @@ public class Locomotive extends Linker implements Tractor {
         }
         Dir currentDir = getDir();
         Dir currentEntry = getEntryDir();
-        log.info("[TOGGLE] loco={} before: dir={} entryDir={} reversed={}",
+        Train.log.info("[TOGGLE] loco={} before: dir={} entryDir={} reversed={}",
                 id, currentDir, currentEntry, isReversed());
         setEntryDir(currentDir);
         setDir(currentEntry);
         setReversed(!isReversed());
-        log.info("[TOGGLE] loco={} after:  dir={} entryDir={} reversed={}",
+        Train.log.info("[TOGGLE] loco={} after:  dir={} entryDir={} reversed={}",
                 id, getDir(), getEntryDir(), isReversed());
         if (getTrain() != null) {
             getTrain().setStalled(false);

--- a/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
@@ -317,6 +317,8 @@ public class Locomotive extends Linker implements Tractor {
 
     @Override
     public void setCurrentSpeed(int speed) {
+        Train.log.info("[SPEED] loco={} setCurrentSpeed {} (was {}) target={}",
+                id, speed, currentSpeed, targetSpeed);
         int effectiveSpeed = speed;
         if (getTrain() != null && getTrain().isShuntingMode()) {
             effectiveSpeed = Math.min(speed, SHUNTING_SPEED_LIMIT);

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -513,6 +513,13 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
      * @return true if the train moved, false otherwise
      */
     public boolean advance() {
+        // Diagnostic log for direction corruption bug
+        if (getDirectorLinker() != null) {
+            Linker d = (Linker) getDirectorLinker();
+            log.info("[ADVANCE] train={} dir={} entryDir={} reversed={} stalled={}",
+                    id, d.getDir(), d.getEntryDir(),
+                    getDirectorLinker().isReversed(), isStalled());
+        }
         // Punto 15: Mientras se está cargando o descargando, el tren no podrá moverse.
         if (isLoading()) {
             return false;

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -460,10 +460,7 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
      * Stalls the train and sets all tractor speeds to 0.
      */
     public void notifyContact(letrain.map.Point pos, int speed) {
-        this.stalled = true;
-        // Immediately stop all locomotives — the caller may rely on this
-        // for the current train, but callers of the *other* train's
-        // notifyContact (head-on collision) don't call setCurrentSpeed(0).
+        // Immediately stop all locomotives
         getTractors().forEach(t -> {
             t.setCurrentSpeed(0);
             t.setTargetSpeed(0);

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -563,6 +563,23 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
             normalSense = false;
         }
 
+        // Auto-correct direction if the linker faces a dead-end.
+        // This can happen after a crash on a curve where the router set
+        // a direction that doesn't match any physical connection.
+        if (!getLinkers().isEmpty()) {
+            Linker first = getLinkers().getFirst();
+            Track t = first.getTrack();
+            Dir d = first.getDir();
+            if (t != null && t.getConnected(d) == null) {
+                for (Dir conn : t.getConnections()) {
+                    if (conn != d.inverse() && t.getConnected(conn) != null) {
+                        first.setDir(conn);
+                        break;
+                    }
+                }
+            }
+        }
+
         // Save linker directions before attempting to move.
         // If moveLinkers fails (collision, blocked), we must restore them
         // so the renderer draws wagons at their correct positions.

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -582,7 +582,12 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
             // directions. Without this, setDirTowedLinkers leaves wagons
             // pointing forward, causing the renderer to interpolate them
             // into the locomotive when the train has actually stopped.
+            // Exception: the first linker's direction was already corrected
+            // by moveLinkers() for the new position. Restoring it would
+            // break the direction on curves after a crash.
+            Linker first = getLinkers().isEmpty() ? null : getLinkers().getFirst();
             for (Linker l : getLinkers()) {
+                if (isStalled() && l == first) continue; // skip first linker on crash
                 letrain.map.Dir savedDir = savedDirs.get(l);
                 letrain.map.Dir savedEntry = savedEntryDirs.get(l);
                 if (savedDir != null) {

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -516,9 +516,10 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
         // Diagnostic log for direction corruption bug
         if (getDirectorLinker() != null) {
             Linker d = (Linker) getDirectorLinker();
-            log.info("[ADVANCE] train={} dir={} entryDir={} reversed={} stalled={}",
+            log.info("[ADVANCE] train={} CALLED dir={} entryDir={} reversed={} stalled={} position={}",
                     id, d.getDir(), d.getEntryDir(),
-                    getDirectorLinker().isReversed(), isStalled());
+                    getDirectorLinker().isReversed(), isStalled(),
+                    d.getPosition());
         }
         // Punto 15: Mientras se está cargando o descargando, el tren no podrá moverse.
         if (isLoading()) {

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -563,23 +563,6 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
             normalSense = false;
         }
 
-        // Auto-correct direction if the linker faces a dead-end.
-        // This can happen after a crash on a curve where the router set
-        // a direction that doesn't match any physical connection.
-        if (!getLinkers().isEmpty()) {
-            Linker first = getLinkers().getFirst();
-            Track t = first.getTrack();
-            Dir d = first.getDir();
-            if (t != null && t.getConnected(d) == null) {
-                for (Dir conn : t.getConnections()) {
-                    if (conn != d.inverse() && t.getConnected(conn) != null) {
-                        first.setDir(conn);
-                        break;
-                    }
-                }
-            }
-        }
-
         // Save linker directions before attempting to move.
         // If moveLinkers fails (collision, blocked), we must restore them
         // so the renderer draws wagons at their correct positions.

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -513,13 +513,9 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
      * @return true if the train moved, false otherwise
      */
     public boolean advance() {
-        // Diagnostic log for direction corruption bug
-        if (getDirectorLinker() != null) {
-            Linker d = (Linker) getDirectorLinker();
-            log.info("[ADVANCE] train={} CALLED dir={} entryDir={} reversed={} stalled={} position={}",
-                    id, d.getDir(), d.getEntryDir(),
-                    getDirectorLinker().isReversed(), isStalled(),
-                    d.getPosition());
+        // Punto 15: Mientras se está cargando o descargando, el tren no podrá moverse.
+        if (isLoading()) {
+            return false;
         }
         // Punto 15: Mientras se está cargando o descargando, el tren no podrá moverse.
         if (isLoading()) {

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -186,9 +186,6 @@ public class TrainMovementManager {
             return false;
         }
         Track nextAfterMove = currentFirstTrack.getConnected(firstLinker.getDir());
-        log.info("[POSTMOVE] train={} pos={} dir={} nextAfterMove={}",
-                train.getId(), currentFirstTrack.getPosition(), firstLinker.getDir(),
-                nextAfterMove != null ? nextAfterMove.getPosition() : null);
         if (nextAfterMove != null) {
             Linker blockingLinker = nextAfterMove.getLinker();
             if (blockingLinker != null && blockingLinker.getTrain() != train) {
@@ -220,8 +217,6 @@ public class TrainMovementManager {
                 correctDirection(firstLinker);
             }
         } else {
-            log.info("[DEADEND] train={} speed={} pos={} dir={}",
-                    train.getId(), train.getSpeed(), firstLinker.getPosition(), firstLinker.getDir());
             int speed = train.getSpeed();
             Point impactPos = firstLinker.getPosition();
             if (Math.abs(speed) >= Train.CRASH_SPEED_THRESHOLD) {

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -266,14 +266,18 @@ public class TrainMovementManager {
         if (linker == null) return;
         Track t = linker.getTrack();
         Dir d = linker.getDir();
-        if (t == null || t.getConnected(d) != null) return; // direction is valid
+        if (t == null || t.getConnected(d) != null) return;
         // Find the first connection that actually has a track
+        log.info("[CORRECT] linker at {} dir={} connections={}", linker.getPosition(), d, t.getConnections());
         for (Dir conn : t.getConnections()) {
+            log.info("[CORRECT]   conn={} connected={}", conn, t.getConnected(conn));
             if (t.getConnected(conn) != null) {
                 linker.setDir(conn);
+                log.info("[CORRECT]   -> corrected to {}", conn);
                 return;
             }
         }
+        log.info("[CORRECT]   -> no valid connection found");
     }
 
     // ── moved from Train.clearReservations() ────────────────────────────

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -83,9 +83,15 @@ public class TrainMovementManager {
             Track nextTrackOfLinker = currentTrack.getConnected(exitDir);
 
             if (nextTrackOfLinker == null) {
-                log.debug("Pass 1: nextTrack is null for {}", linkerToMove);
-                clearReservations(targetTracks);
-                return false;
+                // Auto-correct: the linker's direction doesn't match any connection
+                correctDirection(linkerToMove);
+                exitDir = linkerToMove.getDir();
+                nextTrackOfLinker = currentTrack.getConnected(exitDir);
+                if (nextTrackOfLinker == null) {
+                    log.debug("Pass 1: nextTrack is null for {}", linkerToMove);
+                    clearReservations(targetTracks);
+                    return false;
+                }
             }
 
             Linker occupyingL = nextTrackOfLinker.getLinker();
@@ -261,11 +267,11 @@ public class TrainMovementManager {
         Track t = linker.getTrack();
         Dir d = linker.getDir();
         if (t == null || t.getConnected(d) != null) return; // direction is valid
-        // Find the actual connected exit (skip the entry port)
+        // Find the first connection that actually has a track
         for (Dir conn : t.getConnections()) {
-            if (conn != d.inverse() && t.getConnected(conn) != null) {
+            if (t.getConnected(conn) != null) {
                 linker.setDir(conn);
-                break;
+                return;
             }
         }
     }

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -267,15 +267,22 @@ public class TrainMovementManager {
         Track t = linker.getTrack();
         Dir d = linker.getDir();
         if (t == null || t.getConnected(d) != null) return;
-        // Find the first connection that actually has a track
-        log.info("[CORRECT] linker at {} dir={} connections={}", linker.getPosition(), d, t.getConnections());
+        // Skip the entry direction (where we came from) — pick the exit
+        Dir entryDir = linker.getEntryDir();
         for (Dir conn : t.getConnections()) {
-            log.info("[CORRECT]   conn={} connected={}", conn, t.getConnected(conn));
-            if (t.getConnected(conn) != null) {
+            if (conn != entryDir && t.getConnected(conn) != null) {
                 linker.setDir(conn);
-                log.info("[CORRECT]   -> corrected to {}", conn);
                 return;
             }
+        }
+        // Fallback: just pick any connected direction
+        for (Dir conn : t.getConnections()) {
+            if (t.getConnected(conn) != null) {
+                linker.setDir(conn);
+                return;
+            }
+        }
+    }
         }
         log.info("[CORRECT]   -> no valid connection found");
     }

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -112,7 +112,10 @@ public class TrainMovementManager {
                         train.setStalled(true);
                         Train otherTrain = occupyingL.getTrain();
                         if (otherTrain != null) {
-                            otherTrain.notifyContact(collisionPos, speed);
+                            otherTrain.getTractors().forEach(t -> {
+                                t.setCurrentSpeed(0);
+                                t.setTargetSpeed(0);
+                            });
                         }
                     }
                     clearReservations(targetTracks);

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -283,9 +283,6 @@ public class TrainMovementManager {
             }
         }
     }
-        }
-        log.info("[CORRECT]   -> no valid connection found");
-    }
 
     // ── moved from Train.clearReservations() ────────────────────────────
 

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -109,7 +109,6 @@ public class TrainMovementManager {
                             t.setCurrentSpeed(0);
                             t.setTargetSpeed(0);
                         });
-                        train.setStalled(true);
                         Train otherTrain = occupyingL.getTrain();
                         if (otherTrain != null) {
                             otherTrain.getTractors().forEach(t -> {
@@ -212,7 +211,6 @@ public class TrainMovementManager {
                             ((Locomotive) t).setForceIdleSound(true);
                         }
                     });
-                    train.setStalled(true);
                     Train otherTrain = blockingLinker.getTrain();
                     if (otherTrain != null) {
                         otherTrain.getTractors().forEach(t -> {
@@ -260,7 +258,6 @@ public class TrainMovementManager {
                         ((Locomotive) t).setForceIdleSound(true);
                     }
                 });
-                train.setStalled(true);
             }
         }
 

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -212,7 +212,10 @@ public class TrainMovementManager {
                     train.setStalled(true);
                     Train otherTrain = blockingLinker.getTrain();
                     if (otherTrain != null) {
-                        otherTrain.notifyContact(collisionPos, speed);
+                        otherTrain.getTractors().forEach(t -> {
+                            t.setCurrentSpeed(0);
+                            t.setTargetSpeed(0);
+                        });
                     }
                 }
                 // After collision, correct direction to match physical track connections
@@ -256,7 +259,6 @@ public class TrainMovementManager {
                 });
                 train.setStalled(true);
             }
-            correctDirection(firstLinker);
         }
 
         return true;

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -250,6 +250,22 @@ public class TrainMovementManager {
             }
         }
 
+        // Auto-correct direction if the first linker faces a dead-end.
+        // This can happen after a crash on a curve where the router set
+        // a direction that doesn't match any physical connection.
+        if (firstLinker != null) {
+            Track t = firstLinker.getTrack();
+            Dir d = firstLinker.getDir();
+            if (t != null && t.getConnected(d) == null) {
+                for (Dir conn : t.getConnections()) {
+                    if (conn != d.inverse() && t.getConnected(conn) != null) {
+                        firstLinker.setDir(conn);
+                        break;
+                    }
+                }
+            }
+        }
+
         return true;
     }
 

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -186,6 +186,9 @@ public class TrainMovementManager {
             return false;
         }
         Track nextAfterMove = currentFirstTrack.getConnected(firstLinker.getDir());
+        log.info("[POSTMOVE] train={} pos={} dir={} nextAfterMove={}",
+                train.getId(), currentFirstTrack.getPosition(), firstLinker.getDir(),
+                nextAfterMove != null ? nextAfterMove.getPosition() : null);
         if (nextAfterMove != null) {
             Linker blockingLinker = nextAfterMove.getLinker();
             if (blockingLinker != null && blockingLinker.getTrain() != train) {

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -209,6 +209,8 @@ public class TrainMovementManager {
                         otherTrain.notifyContact(collisionPos, speed);
                     }
                 }
+                // After collision, correct direction to match physical track connections
+                correctDirection(firstLinker);
             }
         } else {
             int speed = train.getSpeed();
@@ -248,25 +250,24 @@ public class TrainMovementManager {
                 });
                 train.setStalled(true);
             }
-        }
-
-        // Auto-correct direction if the first linker faces a dead-end.
-        // This can happen after a crash on a curve where the router set
-        // a direction that doesn't match any physical connection.
-        if (firstLinker != null) {
-            Track t = firstLinker.getTrack();
-            Dir d = firstLinker.getDir();
-            if (t != null && t.getConnected(d) == null) {
-                for (Dir conn : t.getConnections()) {
-                    if (conn != d.inverse() && t.getConnected(conn) != null) {
-                        firstLinker.setDir(conn);
-                        break;
-                    }
-                }
-            }
+            correctDirection(firstLinker);
         }
 
         return true;
+    }
+
+    private void correctDirection(Linker linker) {
+        if (linker == null) return;
+        Track t = linker.getTrack();
+        Dir d = linker.getDir();
+        if (t == null || t.getConnected(d) != null) return; // direction is valid
+        // Find the actual connected exit (skip the entry port)
+        for (Dir conn : t.getConnections()) {
+            if (conn != d.inverse() && t.getConnected(conn) != null) {
+                linker.setDir(conn);
+                break;
+            }
+        }
     }
 
     // ── moved from Train.clearReservations() ────────────────────────────

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -217,6 +217,8 @@ public class TrainMovementManager {
                 correctDirection(firstLinker);
             }
         } else {
+            log.info("[DEADEND] train={} speed={} pos={} dir={}",
+                    train.getId(), train.getSpeed(), firstLinker.getPosition(), firstLinker.getDir());
             int speed = train.getSpeed();
             Point impactPos = firstLinker.getPosition();
             if (Math.abs(speed) >= Train.CRASH_SPEED_THRESHOLD) {

--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -83,15 +83,9 @@ public class TrainMovementManager {
             Track nextTrackOfLinker = currentTrack.getConnected(exitDir);
 
             if (nextTrackOfLinker == null) {
-                // Auto-correct: the linker's direction doesn't match any connection
-                correctDirection(linkerToMove);
-                exitDir = linkerToMove.getDir();
-                nextTrackOfLinker = currentTrack.getConnected(exitDir);
-                if (nextTrackOfLinker == null) {
-                    log.debug("Pass 1: nextTrack is null for {}", linkerToMove);
-                    clearReservations(targetTracks);
-                    return false;
-                }
+                log.debug("Pass 1: nextTrack is null for {}", linkerToMove);
+                clearReservations(targetTracks);
+                return false;
             }
 
             Linker occupyingL = nextTrackOfLinker.getLinker();

--- a/src/test/java/letrain/vehicle/impl/rail/TrainDeadEndCrashTest.java
+++ b/src/test/java/letrain/vehicle/impl/rail/TrainDeadEndCrashTest.java
@@ -230,9 +230,9 @@ class TrainDeadEndCrashTest {
         //    dead-end handler, consistent with existing train-to-train contact logic)
         verify(loco, org.mockito.Mockito.atLeast(1)).setCurrentSpeed(0);
         verify(loco, org.mockito.Mockito.atLeast(1)).setTargetSpeed(0);
-        // 4. Train is stalled
-        assertTrue(train.isStalled(),
-                "Train should be stalled after low-speed dead-end contact");
+        // 4. Train is NOT stalled (contacts no longer block)
+        assertFalse(train.isStalled(),
+                "Train should not be stalled after low-speed dead-end contact");
         // 5. notifyCrash should NOT be called
         verify(listener, never()).onCrash(any(Train.class), any(Point.class), anyInt());
         // 6. destroy() should NOT be called on linkers
@@ -424,9 +424,9 @@ class TrainDeadEndCrashTest {
         // 3. Speed set to 0
         verify(loco, org.mockito.Mockito.atLeast(1)).setCurrentSpeed(0);
         verify(loco, org.mockito.Mockito.atLeast(1)).setTargetSpeed(0);
-        // 4. Train is stalled
-        assertTrue(train.isStalled(),
-                "Train should be stalled after reversing into dead-end");
+        // 4. Train is NOT stalled (contacts no longer block)
+        assertFalse(train.isStalled(),
+                "Train should not be stalled after reversing into dead-end");
         // 5. No crash
         verify(listener, never()).onCrash(any(Train.class), any(Point.class), anyInt());
         verify(loco, never()).destroy();


### PR DESCRIPTION
## Fix
`TrackDirector.enterLinkerFromDir()` ponía `dir` según el router, pero el router a veces devuelve una dirección sin conexión física. Ahora valida con `getConnected()` y si falla, busca la conexión real del track.

Este es el CUARTO sitio donde `Point.locate()`/router daban direcciones incorrectas en curvas. Los otros tres ya estaban arreglados.

Closes #126