### PR TITLE
fix: releaseAll segments on crash to prevent zombie locks

### DIFF
--- a/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainMovementManager.java
@@ -311,6 +311,10 @@ public class TrainMovementManager {
                 l.destroy();
             });
             train.setStalled(true);
+            // Release segments so other trains can use them
+            if (train.getModel() != null) {
+                train.getModel().getBlockManager().releaseAll(train);
+            }
         }
 
         // Also handle the other linker/train
@@ -333,6 +337,9 @@ public class TrainMovementManager {
                     l.destroy();
                 });
                 linker.getTrain().setStalled(true);
+                if (linker.getTrain().getModel() != null) {
+                    linker.getTrain().getModel().getBlockManager().releaseAll(linker.getTrain());
+                }
             }
         } else {
             log.info("crash: Destroying loose linker {} at crash position {}", linker, crashPos);


### PR DESCRIPTION
## Fix
`crash()` ahora llama a `blockManager.releaseAll()` para ambos trenes al destruirlos. Los segmentos ya no se quedan bloqueados permanentemente tras un choque.

Closes #131