### PR TITLE
fix: getLinkDir walk-through follows track connections

### DIFF
--- a/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
@@ -412,17 +412,29 @@ public class TrainCouplingManager {
         // Walk through same-train linkers using track router to find
         // the exit where a different train might be.
         if (adjacentLinker != null && adjacentLinker.getTrain() == train) {
+            // Walk through same-train linkers following track connections outward.
             Track currentTrack = linker.getTrack().getConnected(linkerDir);
+            Track prevTrack = linker.getTrack(); // skip the track we came from
             Linker nextLinker = adjacentLinker;
             while (currentTrack != null && nextLinker != null && nextLinker.getTrain() == train) {
-                // Find the physical connection from currentTrack to nextLinker's track
-                Track nextLinkerTrack = nextLinker.getTrack();
+                // Walk one hop: find a connection that doesn't go back
                 Track nextTrack = null;
                 for (Dir conn : currentTrack.getConnections()) {
-                    if (currentTrack.getConnected(conn) == nextLinkerTrack) {
-                        nextTrack = nextLinkerTrack;
+                    Track t = currentTrack.getConnected(conn);
+                    if (t != null && t != prevTrack) {
+                        nextTrack = t;
                         break;
                     }
+                }
+                if (nextTrack == null) break;
+                prevTrack = currentTrack;
+                currentTrack = nextTrack;
+                nextLinker = currentTrack.getLinker();
+            }
+            if (nextLinker != null && nextLinker.getTrain() != train) {
+                return linkerDir;
+            }
+        }
                 }
                 if (nextTrack == null) break;
                 currentTrack = nextTrack;

--- a/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainCouplingManager.java
@@ -435,15 +435,6 @@ public class TrainCouplingManager {
                 return linkerDir;
             }
         }
-                }
-                if (nextTrack == null) break;
-                currentTrack = nextTrack;
-                nextLinker = currentTrack.getLinker();
-            }
-            if (nextLinker != null && nextLinker.getTrain() != train) {
-                return linkerDir;
-            }
-        }
         return null;
     }
 


### PR DESCRIPTION
## Fix
El walk-through en `getLinkDir` buscaba una conexión de un track a sí mismo (`currentTrack.getConnected(conn) == nextLinkerTrack` donde ambos son el mismo). Como un track nunca se conecta a sí mismo, `nextTrack` siempre era null → rompía en la 1ª iteración.

Ahora camina un salto cada vez siguiendo cualquier conexión que no vuelva al track anterior.

Closes #133