### PR TITLE
docs: ADR-008 — diseño refinado de itinerarios con waypoints y AutoPilot

### DIFF
--- a/docs/adr/ADR-008-Itinerary-Redesigned.md
+++ b/docs/adr/ADR-008-Itinerary-Redesigned.md
@@ -85,6 +85,21 @@ Arista = (Segment A, Segment B) si comparten un RailNode (fork)
 - **Restricción de entrada**: si el waypoint destino tiene `entryDir`, solo se aceptan rutas cuyo último segmento tenga conexión física en esa dirección
 - **Resultado**: lista ordenada de `Segment` desde el actual hasta el destino
 
+### Separación estricta de responsabilidades
+
+El pathfinder es una **función pura**. No controla velocidad, no escucha eventos, no ejecuta comandos, no sabe de trenes:
+
+```
+Pathfinder.find(fromSegment, toSegment, entryDir?) → List<Segment>
+```
+
+El `AutoPilot` es el que **ejecuta**: recibe la ruta del pathfinder y se encarga de:
+- Seguir la secuencia de segmentos
+- Controlar velocidad y frenado
+- Cambiar forks necesarios
+- Detectar llegada al waypoint
+- Ejecutar comandos del waypoint (LOAD, UNLOAD, REVERSE...)
+
 ### Tramos independientes (REVERSE)
 
 Un `REVERSE` parte el itinerario en tramos. Cada tramo se resuelve por separado:
@@ -208,12 +223,12 @@ Transición AUTO → MANUAL:
 
 | Fase | Qué | Prioridad |
 |------|-----|-----------|
-| 1 | `Waypoint`, `WaypointCommand`, `Itinerary` (datos) | Alta |
-| 2 | `SegmentPathfinder` (A*) | Alta |
-| 3 | `AutoPilot` (navegación básica: seguir ruta, cambiar forks, velocidad) | Alta |
+| 1 | `Waypoint`, `WaypointCommand`, `Itinerary` (datos puros) | Alta |
+| 2 | `SegmentPathfinder.find()` — función pura, solo A* | Alta |
+| 3 | `AutoPilot` — ejecuta la ruta: sigue segmentos, cambia forks, controla velocidad | Alta |
 | 4 | Modo dual (MANUAL/AUTO) en Train + UI | Alta |
 | 5 | Comandos REVERSE, WAIT, SPEED | Media |
-| 6 | Fallback y replanificación | Media |
+| 6 | Fallback, replanificación, detección de llegada a waypoint | Media |
 | 7 | Editor visual de itinerarios | Baja |
 
 ---

--- a/docs/adr/ADR-008-Itinerary-Redesigned.md
+++ b/docs/adr/ADR-008-Itinerary-Redesigned.md
@@ -1,0 +1,192 @@
+# ADR-008: Sistema de Itinerarios con Waypoints y Control Automático
+
+## Estado: PROPUESTA
+
+## Contexto
+
+ADR-004 definió las bases de los itinerarios (secuencia de estaciones + AutoPilot). Tras meses de evolución del sistema de bloques (ADR-005), extracción de managers, y estabilización del link/unlink, es el momento de refinar el diseño con lo aprendido.
+
+## Objetivos
+
+1. **Itinerario expresivo**: waypoints mixtos (estaciones, sensores) con comandos asociados
+2. **Pathfinding determinista**: A* sobre el grafo de segmentos, no sobre coordenadas
+3. **Modo dual**: cada tren puede estar en modo MANUAL o AUTOMÁTICO
+4. **Forks bajo control**: en modo automático, el sistema cambia forks; en manual, el jugador
+
+---
+
+## 1. Estructura del Itinerario
+
+### Waypoint
+
+Un `Waypoint` es un punto de paso en el itinerario:
+
+```
+Waypoint {
+    targetType: STATION | SENSOR
+    targetId:   int
+    commands:   List<WaypointCommand>
+}
+```
+
+### WaypointCommand
+
+Acción a ejecutar al llegar al waypoint:
+
+| Comando | Efecto |
+|---------|--------|
+| `LOAD` | Cargar mercancía disponible |
+| `UNLOAD` | Descargar mercancía |
+| `REVERSE` | Invertir marcha (para cambiar de sentido) |
+| `WAIT(n)` | Esperar n ticks |
+| `SPEED(n)` | Fijar velocidad objetivo a n |
+| `NONE` | Solo pasar (sensor de orientación) |
+
+### Ejemplo
+
+```
+Itinerario Tren 1:
+  1. Waypoint(ESTACION, 3) → [LOAD]
+  2. Waypoint(SENSOR, 7)   → []           // forzar paso por aquí
+  3. Waypoint(SENSOR, 2)   → [REVERSE]    // invertir marcha
+  4. Waypoint(ESTACION, 5) → [UNLOAD]
+```
+
+---
+
+## 2. Pathfinding (A* sobre segmentos)
+
+### Grafo de navegación
+
+Los nodos son `Segment` (definidos en ADR-003/ADR-005). Las aristas son las conexiones entre segmentos vía `PathStep` (fork nodes).
+
+```
+Nodo = Segment
+Arista = (Segment A, Segment B) si comparten un RailNode (fork)
+```
+
+### Algoritmo A*
+
+- **Heurística**: distancia Manhattan entre centros de segmento
+- **Coste**: 1 por segmento (todos los segmentos pesan igual)
+- **Resultado**: lista ordenada de `Segment` desde el actual hasta el destino
+
+### Replanificación
+
+Si la ruta se bloquea (segmento ocupado por otro tren), el AutoPilot:
+1. Espera N ticks (configurable)
+2. Recalcula la ruta desde la posición actual
+3. Si no hay ruta alternativa → frena y devuelve control a MANUAL
+
+---
+
+## 3. AutoPilot (Control Automático)
+
+### Ciclo de decisión (cada tick)
+
+```
+1. ¿Estoy en modo AUTOMÁTICO? → seguir
+2. ¿He llegado al waypoint actual?
+   - SÍ → ejecutar comandos del waypoint → avanzar al siguiente
+   - NO → seguir
+3. ¿Tengo ruta calculada?
+   - NO → calcular A* hasta el siguiente waypoint
+4. ¿El siguiente segmento está libre?
+   - SÍ → si hay fork, cambiarlo → avanzar
+   - NO → esperar (o recalcular si timeout)
+5. ¿Velocidad correcta?
+   - Ajustar velocidad según distancia al próximo waypoint
+```
+
+### Gestión de forks
+
+En modo AUTOMÁTICO, el sistema puede cambiar cualquier fork que esté en la ruta del tren, **incluso si el BlockManager lo tiene bloqueado**. Esto resuelve [el problema identificado en #107] donde los forks bloqueados impedían maniobras.
+
+Reglas:
+- Si el fork está en la ruta Y el tren está en modo AUTO → cambiar sin restricción
+- Si el fork está en la ruta Y el tren está en modo MANUAL → NO cambiar (el jugador decide)
+- Si el fork NO está en la ruta de ningún tren → comportamiento normal (ADR-005)
+
+### Inversión atómica
+
+Al ejecutar `REVERSE`:
+1. Parada completa (speed=0)
+2. `releaseAll()` de segmentos que ya no están en la nueva ruta
+3. `toggleReversed()`
+4. Recalcular ruta desde posición actual
+
+### Fallback a manual
+
+El AutoPilot devuelve el control a MANUAL si:
+- No encuentra ruta al siguiente waypoint
+- La ruta está bloqueada más de N ticks sin alternativa
+- El tren sufre un choque o descarrilamiento
+- El jugador pulsa la tecla de modo manual
+
+---
+
+## 4. Modo Dual (MANUAL vs AUTOMÁTICO)
+
+Cada tren tiene un flag `mode: MANUAL | AUTOMÁTICO`.
+
+| Aspecto | MANUAL | AUTOMÁTICO |
+|---------|--------|-------------|
+| Velocidad | Jugador | AutoPilot |
+| Dirección | Jugador | AutoPilot |
+| Forks | Jugador (si no bloqueados) | Sistema (sin restricción) |
+| Link/Unlink | Jugador | Bloqueado |
+| Colisión | Contacto/Crash normal | Frenada emergencia + fallback manual |
+
+Transición MANUAL → AUTO:
+- Solo si existe ruta válida al primer waypoint
+- Solo si el tren está parado (speed=0)
+
+Transición AUTO → MANUAL:
+- Siempre permitida (jugador o fallback)
+
+---
+
+## 5. Integración con el sistema actual
+
+### Nuevas clases
+
+| Clase | Responsabilidad |
+|-------|----------------|
+| `Waypoint` | Record: tipo, id, comandos |
+| `WaypointCommand` | Enum: LOAD, UNLOAD, REVERSE, WAIT, SPEED, NONE |
+| `AutoPilot` | Lógica de navegación por tick |
+| `SegmentPathfinder` | A* sobre RailwayGraph |
+| `Itinerary` (refactor) | Lista de Waypoints + estado actual |
+
+### Modificaciones
+
+| Clase | Cambio |
+|-------|--------|
+| `Train` | Añadir `mode` (MANUAL/AUTO) y `AutoPilot` |
+| `Locomotive.update()` | Si AUTO → delegar en AutoPilot |
+| `ForkRailTrack.flipRoute()` | Si el tren está en AUTO → permitir aunque esté locked |
+| `Gdx3DInputHandler` | Tecla para toggle MANUAL/AUTO |
+
+### UI
+
+- Modo AUTO → línea de dirección en AZUL (en vez de verde/rojo)
+- Itinerario actual visible en HUD
+- Siguiente waypoint marcado en el mapa
+
+---
+
+## 6. Implementación por fases
+
+| Fase | Qué | Prioridad |
+|------|-----|-----------|
+| 1 | `Waypoint`, `WaypointCommand`, `Itinerary` (datos) | Alta |
+| 2 | `SegmentPathfinder` (A*) | Alta |
+| 3 | `AutoPilot` (navegación básica: seguir ruta, cambiar forks, velocidad) | Alta |
+| 4 | Modo dual (MANUAL/AUTO) en Train + UI | Alta |
+| 5 | Comandos REVERSE, WAIT, SPEED | Media |
+| 6 | Fallback y replanificación | Media |
+| 7 | Editor visual de itinerarios | Baja |
+
+---
+
+*Última actualización: 2026-05-13*

--- a/docs/adr/ADR-008-Itinerary-Redesigned.md
+++ b/docs/adr/ADR-008-Itinerary-Redesigned.md
@@ -103,25 +103,25 @@ El `AutoPilot` es el que **ejecuta**: recibe la ruta del pathfinder y se encarga
 
 ### Tramos independientes (REVERSE)
 
-Un `REVERSE` parte el itinerario en tramos. Cada tramo se resuelve por separado:
+El pathfinder **nunca calcula el itinerario completo de golpe**. Siempre lo hace entre waypoints consecutivos:
 
-```
-[Est 3] → [Sensor 7] → [Sensor 2 REVERSE] → [Est 5]
+**En creación** (modo edición):
+- Validar que cada par `waypoint[i] → waypoint[i+1]` es alcanzable
+- Si algún par falla → el itinerario no se puede crear
 
-Tramo 1: posición actual → Sensor 2       [A* normal]
-Tramo 2: Sensor 2 (invertido) → Est 5     [A* nuevo]
-```
+**En ejecución** (modo AutoPilot):
+- Calcular ruta al waypoint actual → recorrerla → llegar → siguiente waypoint
+- El pathfinder se llama de nuevo para cada tramo (la topología pudo cambiar)
 
-- El pathfinder solo calcula de waypoint a waypoint dentro del mismo tramo
-- Si un tramo pasa dos veces por el mismo segmento (ida y vuelta), son tramos distintos → sin conflicto
-- Al ejecutar REVERSE, el AutoPilot invierte la marcha y recalcula desde cero
+Un `REVERSE` simplemente invierte la marcha y recalcula desde la nueva orientación al siguiente waypoint. No requiere estructura de datos especial.
 
 ### Replanificación
 
 Si la ruta se bloquea (segmento ocupado por otro tren), el AutoPilot:
-1. Espera N ticks (configurable)
+1. Espera N ticks (configurable, ej. 300 = 15 segundos)
 2. Recalcula la ruta desde la posición actual
-3. Si no hay ruta alternativa → frena y devuelve control a MANUAL
+3. Si sigue bloqueado → vuelve a esperar y reintenta
+4. Solo pasa a MANUAL si la ruta es **estructuralmente imposible** (topología cambió, waypoint desapareció, el tren descarriló)
 
 ---
 
@@ -162,11 +162,12 @@ Al ejecutar `REVERSE`:
 
 ### Fallback a manual
 
-El AutoPilot devuelve el control a MANUAL si:
-- No encuentra ruta al siguiente waypoint
-- La ruta está bloqueada más de N ticks sin alternativa
+El AutoPilot solo devuelve el control a MANUAL si:
+- La ruta es estructuralmente imposible (topología cambió, el waypoint ya no existe)
 - El tren sufre un choque o descarrilamiento
 - El jugador pulsa la tecla de modo manual
+
+Un bloqueo temporal NUNCA provoca fallback — solo espera y reintenta.
 
 ---
 
@@ -180,14 +181,24 @@ Cada tren tiene un flag `mode: MANUAL | AUTOMÁTICO`.
 | Dirección | Jugador | AutoPilot |
 | Forks | Jugador (si no bloqueados) | Sistema (sin restricción) |
 | Link/Unlink | Jugador | Bloqueado |
-| Colisión | Contacto/Crash normal | Frenada emergencia + fallback manual |
+| Colisión | Contacto/Crash normal | Frenada emergencia + reintento |
 
 Transición MANUAL → AUTO:
+- El jugador pulsa una tecla en modo DRIVE
+- Solo si el tren tiene un itinerario asignado
 - Solo si existe ruta válida al primer waypoint
 - Solo si el tren está parado (speed=0)
 
 Transición AUTO → MANUAL:
-- Siempre permitida (jugador o fallback)
+- El jugador pulsa la tecla de modo
+- El jugador cambia la velocidad manualmente (incSpeed/decSpeed)
+- Choque o descarrilamiento
+
+### Asignación de itinerarios
+
+- En el editor de itinerarios, se asigna un itinerario a uno o varios trenes (relación 1:N)
+- Un tren con itinerario asignado NO está en automático hasta que el jugador lo active
+- El jugador decide cuándo arrancar cada tren en automático desde el modo DRIVE
 
 ---
 
@@ -210,7 +221,7 @@ Transición AUTO → MANUAL:
 | `Train` | Añadir `mode` (MANUAL/AUTO) y `AutoPilot` |
 | `Locomotive.update()` | Si AUTO → delegar en AutoPilot |
 | `ForkRailTrack.flipRoute()` | Si el tren está en AUTO → permitir aunque esté locked |
-| `Gdx3DInputHandler` | Tecla para toggle MANUAL/AUTO |
+| `Gdx3DInputHandler` | Tecla en modo DRIVE para toggle MANUAL/AUTO; cambio de velocidad → AUTO→MANUAL |
 | `Itinerary` | Refactorizar: `List<Waypoint>` + estado en vez de `List<Stop>` |
 
 ### UI
@@ -231,7 +242,7 @@ Transición AUTO → MANUAL:
 | 4 | Modo dual (MANUAL/AUTO) en Train + UI | Alta |
 | 5 | Comandos REVERSE, WAIT, SPEED | Media |
 | 6 | Fallback, replanificación, detección de llegada a waypoint | Media |
-| 7 | Editor visual de itinerarios | Baja |
+| 7 | Editor visual de itinerarios (ver `ADR-009-Itinerary-Editor`) | Baja |
 
 ---
 

--- a/docs/adr/ADR-008-Itinerary-Redesigned.md
+++ b/docs/adr/ADR-008-Itinerary-Redesigned.md
@@ -80,8 +80,9 @@ Arista = (Segment A, Segment B) si comparten un RailNode (fork)
 
 ### Algoritmo A*
 
-- **Heurística**: distancia Manhattan entre los centros de los segmentos (o entre sus nodos extremo)
-- **Coste de arista**: número de `RailTrack`s que contiene el segmento (longitud real)
+- **Heurística h(n)**: distancia Manhattan desde el nodo de salida del segmento actual hasta el nodo de entrada del segmento destino, más la distancia desde ese nodo hasta el track concreto del destino (estación/sensor)
+- **Coste de arista g(n)**: número de `RailTrack`s que contiene el segmento (longitud real)
+- **Coste inicial g(0)**: distancia desde el track actual del tren hasta el nodo de salida de su segmento
 - **Restricción de entrada**: si el waypoint destino tiene `entryDir`, solo se aceptan rutas cuyo último segmento tenga conexión física en esa dirección
 - **Resultado**: lista ordenada de `Segment` desde el actual hasta el destino
 

--- a/docs/adr/ADR-008-Itinerary-Redesigned.md
+++ b/docs/adr/ADR-008-Itinerary-Redesigned.md
@@ -19,7 +19,18 @@ ADR-004 definió las bases de los itinerarios (secuencia de estaciones + AutoPil
 
 ### Waypoint
 
-Un `Waypoint` es un punto de paso en el itinerario:
+Un `Waypoint` es un punto de paso en el itinerario. Opcionalmente puede especificar la **dirección de entrada** deseada:
+
+```
+Waypoint {
+    targetType:  STATION | SENSOR
+    targetId:    int
+    entryDir:    Dir | null     // dirección por la que debe entrar (ej: SW, N)
+    commands:    List<WaypointCommand>
+}
+```
+
+Si `entryDir` no es null, el pathfinder solo considerará rutas que lleguen al segmento del destino por esa dirección de entrada. Si es null, cualquier entrada es válida.
 
 ```
 Waypoint {
@@ -41,6 +52,8 @@ Acción a ejecutar al llegar al waypoint:
 | `WAIT(n)` | Esperar n ticks |
 | `SPEED(n)` | Fijar velocidad objetivo a n |
 | `NONE` | Solo pasar (sensor de orientación) |
+
+Las acciones de carga y descarga sobre un sensor no tendrán efecto alguno.
 
 ### Ejemplo
 
@@ -69,7 +82,23 @@ Arista = (Segment A, Segment B) si comparten un RailNode (fork)
 
 - **Heurística**: distancia Manhattan entre centros de segmento
 - **Coste**: 1 por segmento (todos los segmentos pesan igual)
+- **Restricción de entrada**: si el waypoint destino tiene `entryDir`, solo se aceptan rutas cuyo último segmento tenga conexión física en esa dirección
 - **Resultado**: lista ordenada de `Segment` desde el actual hasta el destino
+
+### Tramos independientes (REVERSE)
+
+Un `REVERSE` parte el itinerario en tramos. Cada tramo se resuelve por separado:
+
+```
+[Est 3] → [Sensor 7] → [Sensor 2 REVERSE] → [Est 5]
+
+Tramo 1: posición actual → Sensor 2       [A* normal]
+Tramo 2: Sensor 2 (invertido) → Est 5     [A* nuevo]
+```
+
+- El pathfinder solo calcula de waypoint a waypoint dentro del mismo tramo
+- Si un tramo pasa dos veces por el mismo segmento (ida y vuelta), son tramos distintos → sin conflicto
+- Al ejecutar REVERSE, el AutoPilot invierte la marcha y recalcula desde cero
 
 ### Replanificación
 

--- a/docs/adr/ADR-008-Itinerary-Redesigned.md
+++ b/docs/adr/ADR-008-Itinerary-Redesigned.md
@@ -201,7 +201,7 @@ Transición AUTO → MANUAL:
 | `WaypointCommand` | Enum: LOAD, UNLOAD, REVERSE, WAIT, SPEED, NONE |
 | `AutoPilot` | Lógica de navegación por tick |
 | `SegmentPathfinder` | A* sobre RailwayGraph |
-| `Itinerary` (refactor) | Lista de Waypoints + estado actual |
+| `Itinerary` (refactor) | `List<Waypoint>` + `currentIndex` + `state` (ACTIVE/PAUSED/DONE). Sustituye al actual `List<Stop>` |
 
 ### Modificaciones
 
@@ -211,6 +211,7 @@ Transición AUTO → MANUAL:
 | `Locomotive.update()` | Si AUTO → delegar en AutoPilot |
 | `ForkRailTrack.flipRoute()` | Si el tren está en AUTO → permitir aunque esté locked |
 | `Gdx3DInputHandler` | Tecla para toggle MANUAL/AUTO |
+| `Itinerary` | Refactorizar: `List<Waypoint>` + estado en vez de `List<Stop>` |
 
 ### UI
 

--- a/docs/adr/ADR-008-Itinerary-Redesigned.md
+++ b/docs/adr/ADR-008-Itinerary-Redesigned.md
@@ -80,8 +80,8 @@ Arista = (Segment A, Segment B) si comparten un RailNode (fork)
 
 ### Algoritmo A*
 
-- **Heurística**: distancia Manhattan entre centros de segmento
-- **Coste**: 1 por segmento (todos los segmentos pesan igual)
+- **Heurística**: distancia Manhattan entre los centros de los segmentos (o entre sus nodos extremo)
+- **Coste de arista**: número de `RailTrack`s que contiene el segmento (longitud real)
 - **Restricción de entrada**: si el waypoint destino tiene `entryDir`, solo se aceptan rutas cuyo último segmento tenga conexión física en esa dirección
 - **Resultado**: lista ordenada de `Segment` desde el actual hasta el destino
 

--- a/docs/adr/ADR-009-Itinerary-Editor.md
+++ b/docs/adr/ADR-009-Itinerary-Editor.md
@@ -1,0 +1,89 @@
+# ADR-009: Editor de Itinerarios (Diseño UI)
+
+## Estado: PROPUESTA / REFERENCIA
+
+> Documento recuperado del diseño original. Sirve como referencia para la Fase 7 de ADR-008.
+
+---
+
+# EDITOR DE ITINERARIOS
+- Un itinerario es una lista ordenada de estaciones, cada una con una acción a realizar. 
+- Cada estación, si no tiene nombre aparecerá como "Estación n" siendo n su id
+- Cada itinerario, si no tiene nombre se llamará "a -> b", con el nombre de la primera estación como a y el de la última como b. **El nombre se regenera dinámicamente** — solo se usa como fallback cuando no se ha dado un nombre explícito.
+- Se mostrará una lista de itinerarios con dos campos: el nombre del itinerario y el id del posible tren al que se asigna y un id del tren al que se ha asignado
+- Mostrará la lista de itinerarios, cada uno con su nombre y el id del tren al que se ha asignado
+- Permitirá agregar, eliminar o editar cada itinerario
+- Permitirá asignarle o quitarle un tren, a elegir entre los que hay
+- Si una estación no se puede alcanzar, siguiendo el itinerario desde la primera estación, no se podrá agregar
+- **Un tren solo puede tener asignado UN itinerario a la vez** (relación 1:1)
+- **Un itinerario no se puede guardar hasta que tenga al menos 2 estaciones**
+- **Cada vez que se cambia algo del mapa, hay que llamar a `model.analyzeInfrastructure()`** para que se rediscoveran los cantones y se revaliden las rutas
+ 
+
+## Ventana Principal: Lista de Itinerarios
+**Propósito**: Listar itinerarios y gestionar asignaciones de tren.
+
+```
+┌─────────────────────────────────────────┐
+│            Itinerarios                  │
+├─────────────────────────────────────────┤
+│ Ruta                │ Tren              │
+├─────────────────────────────────────────┤
+│ Paris → Barcelona   │ [Train 2    ▼]    │
+│ Vigo → Ourense      │ [           ▼]    │
+│ Madrid → Toledo     │ [Train 1    ▼]    │
+├─────────────────────────────────────────┤
+│[Agregar]    [Eliminar]                  │
+│                                         │
+│                     [Aceptar][Cancelar] │
+└─────────────────────────────────────────┘
+
+```
+
+**Detalles**:
+- **Encabezados**: Dos columnas con "Ruta" y "Tren"
+- **Dropdown de tren**: Muestra trenes disponibles + opción vacía para desasignar
+- **`[ ]` (vacío)**: Indica itinerario sin tren asignado
+- **Botón `[Agregar]`**: Crea nuevo itinerario (abre ventana de detalle)
+- **Botón `[Eliminar]`**: Elimina el itinerario seleccionado
+- **Doble clic o Enter** en fila: Abre ventana de detalle para editar estaciones
+- **Tecla Suprimir**: Elimina el itinerario seleccionado
+- Validación de relaciones 1:1: solo se permiten asignar trenes que no tengan ya un itinerario asignado
+
+## Ventana de Detalle: Editor de Estaciones
+**Propósito**: Editar las estaciones y sus acciones. Los trenes se gestionan en la ventana principal.
+
+```
+┌─────────────────────────────────────────┐
+│ Itinerario [Madrid → Salamanca ]        │
+├─────────────────────────────────────────┤
+│ Estaciones:                             │
+│ ┌─────────────────────────────────────┐ │
+│ │ Madrid         │ [PASO      ▼]      │ │
+│ │ Ciudad Real    │ [PARADA    ▼]      │ │
+│ │ Zamora         │ [CARGA     ▼]      │ │
+│ │ Salamanca      │ [DESCARGA  ▼]      │ │
+│ └─────────────────────────────────────┘ │
+│ [Agregar]  [Eliminar]                   │
+│                      [Aceptar][Cancelar]│
+└─────────────────────────────────────────┘
+```
+
+**Detalles**:
+- **Campo nombre**: Editable, con valor por defecto generado automáticamente ("origen → destino")
+- **Lista de estaciones**: 
+  - Columna izquierda: Nombre de la estación (no editable). Si no tiene nombre, se muestra "Estación n"
+  - Columna derecha: Dropdown con acciones disponibles [PASO | PARADA | CARGA | DESCARGA]
+- **Botón `[Agregar]`**: Abre selector de estaciones alcanzables desde la última estación de la lista. Solo se pueden agregar estaciones que tengan ruta desde la última estación.
+- **Botón `[Eliminar]`**: Elimina la estación seleccionada
+- **Tecla Suprimir**: También elimina la estación seleccionada
+- **Validación**: El itinerario debe tener al menos 2 estaciones para poder guardar
+- **NO hay campo de tren**: La asignación se hace en la ventana principal
+
+## Reglas de Validación
+- **Nombre dinámico**: Si no se especifica un nombre, se genera como "origen → destino". El nombre se regenera automáticamente si cambian las estaciones.
+- **Estaciones alcanzables**: Solo se pueden agregar estaciones que tengan ruta desde la última estación del itinerario
+- **Mínimo de estaciones**: Un itinerario no se puede guardar con menos de 2 estaciones
+- **Relación 1:1 tren-itinerario**: Un tren solo puede tener un itinerario asignado, y un itinerario solo puede tener un tren asignado
+- **Validación de infraestructura**: Cada vez que se modifica el mapa, debe llamarse a `model.analyzeInfrastructure()` para redescubrir cantones y revalidar rutas
+


### PR DESCRIPTION
## ADR-008: Sistema de Itinerarios con Waypoints y Control Automático

Refina ADR-004 con el diseño aprendido tras meses de evolución:

- **Waypoints mixtos**: estaciones + sensores con comandos (LOAD, UNLOAD, REVERSE, WAIT, SPEED)
- **Pathfinding**: A* sobre el grafo de segmentos
- **Modo dual**: MANUAL vs AUTOMÁTICO por tren
- **Forks**: en AUTO el sistema los controla sin restricción; en MANUAL el jugador
- **AutoPilot**: navegación tick a tick con replanificación y fallback a manual
- **7 fases de implementación** priorizadas

Ver `docs/adr/ADR-008-Itinerary-Redesigned.md`