### PR TITLE
feat(phase1): data structures — Waypoint, WaypointCommand, Itinerary (TDD)

### DIFF
--- a/src/main/java/letrain/itinerary/Itinerary.java
+++ b/src/main/java/letrain/itinerary/Itinerary.java
@@ -1,0 +1,64 @@
+package letrain.itinerary;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A sequence of waypoints that a train can follow automatically.
+ * Supports N:1 train assignment (one itinerary → many trains).
+ */
+public class Itinerary {
+    public enum State { CREATED, ACTIVE, PAUSED, DONE }
+
+    private final List<Waypoint> waypoints = new ArrayList<>();
+    private final Set<Integer> assignedTrains = new HashSet<>();
+    private State state = State.CREATED;
+    private int currentIndex = 0;
+
+    public void addWaypoint(Waypoint wp) {
+        waypoints.add(wp);
+    }
+
+    public List<Waypoint> waypoints() {
+        return Collections.unmodifiableList(waypoints);
+    }
+
+    public State state() { return state; }
+
+    public boolean isValid() {
+        return waypoints.size() >= 2;
+    }
+
+    public int currentIndex() { return currentIndex; }
+
+    public void advance() {
+        currentIndex++;
+        if (currentIndex >= waypoints.size()) {
+            state = State.DONE;
+            currentIndex = waypoints.size();
+        }
+    }
+
+    public Optional<Waypoint> currentWaypoint() {
+        if (currentIndex < waypoints.size()) {
+            return Optional.of(waypoints.get(currentIndex));
+        }
+        return Optional.empty();
+    }
+
+    public void assignTrain(int trainId) {
+        assignedTrains.add(trainId);
+    }
+
+    public void unassignTrain(int trainId) {
+        assignedTrains.remove(trainId);
+    }
+
+    public Set<Integer> assignedTrains() {
+        return Collections.unmodifiableSet(assignedTrains);
+    }
+}

--- a/src/main/java/letrain/itinerary/Itinerary.java
+++ b/src/main/java/letrain/itinerary/Itinerary.java
@@ -1,64 +1,20 @@
 package letrain.itinerary;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-/**
- * A sequence of waypoints that a train can follow automatically.
- * Supports N:1 train assignment (one itinerary → many trains).
- */
-public class Itinerary {
-    public enum State { CREATED, ACTIVE, PAUSED, DONE }
+public interface Itinerary {
+    enum State { CREATED, ACTIVE, PAUSED, DONE }
 
-    private final List<Waypoint> waypoints = new ArrayList<>();
-    private final Set<Integer> assignedTrains = new HashSet<>();
-    private State state = State.CREATED;
-    private int currentIndex = 0;
-
-    public void addWaypoint(Waypoint wp) {
-        waypoints.add(wp);
-    }
-
-    public List<Waypoint> waypoints() {
-        return Collections.unmodifiableList(waypoints);
-    }
-
-    public State state() { return state; }
-
-    public boolean isValid() {
-        return waypoints.size() >= 2;
-    }
-
-    public int currentIndex() { return currentIndex; }
-
-    public void advance() {
-        currentIndex++;
-        if (currentIndex >= waypoints.size()) {
-            state = State.DONE;
-            currentIndex = waypoints.size();
-        }
-    }
-
-    public Optional<Waypoint> currentWaypoint() {
-        if (currentIndex < waypoints.size()) {
-            return Optional.of(waypoints.get(currentIndex));
-        }
-        return Optional.empty();
-    }
-
-    public void assignTrain(int trainId) {
-        assignedTrains.add(trainId);
-    }
-
-    public void unassignTrain(int trainId) {
-        assignedTrains.remove(trainId);
-    }
-
-    public Set<Integer> assignedTrains() {
-        return Collections.unmodifiableSet(assignedTrains);
-    }
+    void addWaypoint(Waypoint wp);
+    List<Waypoint> waypoints();
+    State state();
+    boolean isValid();
+    int currentIndex();
+    void advance();
+    Optional<Waypoint> currentWaypoint();
+    void assignTrain(int trainId);
+    void unassignTrain(int trainId);
+    Set<Integer> assignedTrains();
 }

--- a/src/main/java/letrain/itinerary/Waypoint.java
+++ b/src/main/java/letrain/itinerary/Waypoint.java
@@ -4,23 +4,10 @@ import java.util.List;
 import java.util.Optional;
 import letrain.map.Dir;
 
-/**
- * A waypoint in an itinerary. Can be a station or a sensor, with optional
- * entry direction and commands to execute on arrival.
- */
-public record Waypoint(
-    Type type,
-    int targetId,
-    Optional<Dir> entryDir,
-    List<WaypointCommand> commands
-) {
-    public enum Type { STATION, SENSOR }
-
-    public Waypoint(Type type, int targetId, List<WaypointCommand> commands) {
-        this(type, targetId, Optional.empty(), commands);
-    }
-
-    public Waypoint(Type type, int targetId, Dir entryDir, List<WaypointCommand> commands) {
-        this(type, targetId, Optional.of(entryDir), commands);
-    }
+public interface Waypoint {
+    enum Type { STATION, SENSOR }
+    Type type();
+    int targetId();
+    Optional<Dir> entryDir();
+    List<WaypointCommand> commands();
 }

--- a/src/main/java/letrain/itinerary/Waypoint.java
+++ b/src/main/java/letrain/itinerary/Waypoint.java
@@ -1,0 +1,26 @@
+package letrain.itinerary;
+
+import java.util.List;
+import java.util.Optional;
+import letrain.map.Dir;
+
+/**
+ * A waypoint in an itinerary. Can be a station or a sensor, with optional
+ * entry direction and commands to execute on arrival.
+ */
+public record Waypoint(
+    Type type,
+    int targetId,
+    Optional<Dir> entryDir,
+    List<WaypointCommand> commands
+) {
+    public enum Type { STATION, SENSOR }
+
+    public Waypoint(Type type, int targetId, List<WaypointCommand> commands) {
+        this(type, targetId, Optional.empty(), commands);
+    }
+
+    public Waypoint(Type type, int targetId, Dir entryDir, List<WaypointCommand> commands) {
+        this(type, targetId, Optional.of(entryDir), commands);
+    }
+}

--- a/src/main/java/letrain/itinerary/WaypointCommand.java
+++ b/src/main/java/letrain/itinerary/WaypointCommand.java
@@ -1,0 +1,61 @@
+package letrain.itinerary;
+
+/**
+ * A command to execute when a waypoint is reached.
+ * Simple commands (LOAD, UNLOAD, REVERSE, NONE) are constants.
+ * Parameterized commands (WAIT, SPEED) use factory methods.
+ */
+public class WaypointCommand {
+    public enum Kind { LOAD, UNLOAD, REVERSE, WAIT, SPEED, NONE }
+
+    public static final WaypointCommand LOAD    = new WaypointCommand(Kind.LOAD);
+    public static final WaypointCommand UNLOAD  = new WaypointCommand(Kind.UNLOAD);
+    public static final WaypointCommand REVERSE = new WaypointCommand(Kind.REVERSE);
+    public static final WaypointCommand NONE    = new WaypointCommand(Kind.NONE);
+
+    private final Kind kind;
+    private final int ticks;
+    private final int targetSpeed;
+
+    private WaypointCommand(Kind kind) {
+        this(kind, 0, 0);
+    }
+
+    private WaypointCommand(Kind kind, int ticks, int targetSpeed) {
+        this.kind = kind;
+        this.ticks = ticks;
+        this.targetSpeed = targetSpeed;
+    }
+
+    public static WaypointCommand waitTicks(int ticks) {
+        return new WaypointCommand(Kind.WAIT, ticks, 0);
+    }
+
+    public static WaypointCommand speed(int targetSpeed) {
+        return new WaypointCommand(Kind.SPEED, 0, targetSpeed);
+    }
+
+    public Kind kind()        { return kind; }
+    public int ticks()        { return ticks; }
+    public int targetSpeed()  { return targetSpeed; }
+
+    public boolean isReverse() { return kind == Kind.REVERSE; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof WaypointCommand c)) return false;
+        return kind == c.kind && ticks == c.ticks && targetSpeed == c.targetSpeed;
+    }
+
+    @Override
+    public int hashCode() { return kind.hashCode() ^ ticks ^ targetSpeed; }
+
+    @Override
+    public String toString() {
+        return switch (kind) {
+            case WAIT -> "WAIT(" + ticks + ")";
+            case SPEED -> "SPEED(" + targetSpeed + ")";
+            default -> kind.name();
+        };
+    }
+}

--- a/src/main/java/letrain/itinerary/impl/ItineraryImpl.java
+++ b/src/main/java/letrain/itinerary/impl/ItineraryImpl.java
@@ -1,0 +1,70 @@
+package letrain.itinerary.impl;
+
+import letrain.itinerary.Itinerary;
+import letrain.itinerary.Waypoint;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public class ItineraryImpl implements Itinerary {
+    private final List<Waypoint> waypoints = new ArrayList<>();
+    private final Set<Integer> assignedTrains = new HashSet<>();
+    private State state = State.CREATED;
+    private int currentIndex = 0;
+
+    @Override
+    public void addWaypoint(Waypoint wp) {
+        waypoints.add(wp);
+    }
+
+    @Override
+    public List<Waypoint> waypoints() {
+        return Collections.unmodifiableList(waypoints);
+    }
+
+    @Override
+    public State state() { return state; }
+
+    @Override
+    public boolean isValid() {
+        return waypoints.size() >= 2;
+    }
+
+    @Override
+    public int currentIndex() { return currentIndex; }
+
+    @Override
+    public void advance() {
+        currentIndex++;
+        if (currentIndex >= waypoints.size()) {
+            state = State.DONE;
+            currentIndex = waypoints.size();
+        }
+    }
+
+    @Override
+    public Optional<Waypoint> currentWaypoint() {
+        if (currentIndex < waypoints.size()) {
+            return Optional.of(waypoints.get(currentIndex));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void assignTrain(int trainId) {
+        assignedTrains.add(trainId);
+    }
+
+    @Override
+    public void unassignTrain(int trainId) {
+        assignedTrains.remove(trainId);
+    }
+
+    @Override
+    public Set<Integer> assignedTrains() {
+        return Collections.unmodifiableSet(assignedTrains);
+    }
+}

--- a/src/main/java/letrain/itinerary/impl/WaypointImpl.java
+++ b/src/main/java/letrain/itinerary/impl/WaypointImpl.java
@@ -1,0 +1,23 @@
+package letrain.itinerary.impl;
+
+import letrain.itinerary.Waypoint;
+import letrain.itinerary.WaypointCommand;
+import letrain.map.Dir;
+import java.util.List;
+import java.util.Optional;
+
+public record WaypointImpl(
+    Waypoint.Type type,
+    int targetId,
+    Optional<Dir> entryDir,
+    List<WaypointCommand> commands
+) implements Waypoint {
+
+    public WaypointImpl(Waypoint.Type type, int targetId, List<WaypointCommand> commands) {
+        this(type, targetId, Optional.empty(), commands);
+    }
+
+    public WaypointImpl(Waypoint.Type type, int targetId, Dir entryDir, List<WaypointCommand> commands) {
+        this(type, targetId, Optional.of(entryDir), commands);
+    }
+}

--- a/src/test/java/letrain/itinerary/ItineraryTest.java
+++ b/src/test/java/letrain/itinerary/ItineraryTest.java
@@ -1,5 +1,7 @@
 package letrain.itinerary;
 
+import letrain.itinerary.impl.ItineraryImpl;
+import letrain.itinerary.impl.WaypointImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,7 +15,7 @@ class ItineraryTest {
     @Test
     @DisplayName("should create empty itinerary")
     void emptyItinerary() {
-        Itinerary it = new Itinerary();
+        Itinerary it = new ItineraryImpl();
         assertTrue(it.waypoints().isEmpty());
         assertEquals(Itinerary.State.CREATED, it.state());
     }
@@ -21,10 +23,10 @@ class ItineraryTest {
     @Test
     @DisplayName("should add waypoints")
     void addWaypoints() {
-        Itinerary it = new Itinerary();
-        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of(WaypointCommand.LOAD)));
-        it.addWaypoint(new Waypoint(Waypoint.Type.SENSOR, 7, List.of()));
-        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 5, List.of(WaypointCommand.UNLOAD)));
+        Itinerary it = new ItineraryImpl();
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.STATION, 1, List.of(WaypointCommand.LOAD)));
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.SENSOR, 7, List.of()));
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.STATION, 5, List.of(WaypointCommand.UNLOAD)));
 
         assertEquals(3, it.waypoints().size());
         assertEquals(1, it.waypoints().get(0).targetId());
@@ -35,26 +37,26 @@ class ItineraryTest {
     @Test
     @DisplayName("should not be valid with less than 2 waypoints")
     void needsTwoWaypoints() {
-        Itinerary it = new Itinerary();
-        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of()));
+        Itinerary it = new ItineraryImpl();
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.STATION, 1, List.of()));
         assertFalse(it.isValid());
     }
 
     @Test
     @DisplayName("should be valid with 2 or more waypoints")
     void validWithTwoWaypoints() {
-        Itinerary it = new Itinerary();
-        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of()));
-        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 2, List.of()));
+        Itinerary it = new ItineraryImpl();
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.STATION, 1, List.of()));
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.STATION, 2, List.of()));
         assertTrue(it.isValid());
     }
 
     @Test
     @DisplayName("should track current waypoint index")
     void currentIndex() {
-        Itinerary it = new Itinerary();
-        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of()));
-        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 2, List.of()));
+        Itinerary it = new ItineraryImpl();
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.STATION, 1, List.of()));
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.STATION, 2, List.of()));
 
         assertEquals(0, it.currentIndex());
         it.advance();
@@ -67,9 +69,9 @@ class ItineraryTest {
     @Test
     @DisplayName("should be done when all waypoints visited")
     void doneWhenAllVisited() {
-        Itinerary it = new Itinerary();
-        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of()));
-        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 2, List.of()));
+        Itinerary it = new ItineraryImpl();
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.STATION, 1, List.of()));
+        it.addWaypoint(new WaypointImpl(Waypoint.Type.STATION, 2, List.of()));
 
         it.advance();
         it.advance();
@@ -79,9 +81,9 @@ class ItineraryTest {
     @Test
     @DisplayName("should return current waypoint")
     void currentWaypoint() {
-        Itinerary it = new Itinerary();
-        Waypoint wp1 = new Waypoint(Waypoint.Type.STATION, 1, List.of());
-        Waypoint wp2 = new Waypoint(Waypoint.Type.STATION, 2, List.of());
+        Itinerary it = new ItineraryImpl();
+        Waypoint wp1 = new WaypointImpl(Waypoint.Type.STATION, 1, List.of());
+        Waypoint wp2 = new WaypointImpl(Waypoint.Type.STATION, 2, List.of());
         it.addWaypoint(wp1);
         it.addWaypoint(wp2);
 
@@ -93,7 +95,7 @@ class ItineraryTest {
     @Test
     @DisplayName("should allow assigning to multiple trains")
     void multipleTrains() {
-        Itinerary it = new Itinerary();
+        Itinerary it = new ItineraryImpl();
         it.assignTrain(1);
         it.assignTrain(2);
         it.assignTrain(3);
@@ -107,7 +109,7 @@ class ItineraryTest {
     @Test
     @DisplayName("should allow unassigning trains")
     void unassignTrain() {
-        Itinerary it = new Itinerary();
+        Itinerary it = new ItineraryImpl();
         it.assignTrain(1);
         it.assignTrain(2);
         it.unassignTrain(1);

--- a/src/test/java/letrain/itinerary/ItineraryTest.java
+++ b/src/test/java/letrain/itinerary/ItineraryTest.java
@@ -1,0 +1,118 @@
+package letrain.itinerary;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DisplayName("Itinerary")
+class ItineraryTest {
+
+    @Test
+    @DisplayName("should create empty itinerary")
+    void emptyItinerary() {
+        Itinerary it = new Itinerary();
+        assertTrue(it.waypoints().isEmpty());
+        assertEquals(Itinerary.State.CREATED, it.state());
+    }
+
+    @Test
+    @DisplayName("should add waypoints")
+    void addWaypoints() {
+        Itinerary it = new Itinerary();
+        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of(WaypointCommand.LOAD)));
+        it.addWaypoint(new Waypoint(Waypoint.Type.SENSOR, 7, List.of()));
+        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 5, List.of(WaypointCommand.UNLOAD)));
+
+        assertEquals(3, it.waypoints().size());
+        assertEquals(1, it.waypoints().get(0).targetId());
+        assertEquals(7, it.waypoints().get(1).targetId());
+        assertEquals(5, it.waypoints().get(2).targetId());
+    }
+
+    @Test
+    @DisplayName("should not be valid with less than 2 waypoints")
+    void needsTwoWaypoints() {
+        Itinerary it = new Itinerary();
+        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of()));
+        assertFalse(it.isValid());
+    }
+
+    @Test
+    @DisplayName("should be valid with 2 or more waypoints")
+    void validWithTwoWaypoints() {
+        Itinerary it = new Itinerary();
+        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of()));
+        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 2, List.of()));
+        assertTrue(it.isValid());
+    }
+
+    @Test
+    @DisplayName("should track current waypoint index")
+    void currentIndex() {
+        Itinerary it = new Itinerary();
+        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of()));
+        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 2, List.of()));
+
+        assertEquals(0, it.currentIndex());
+        it.advance();
+        assertEquals(1, it.currentIndex());
+        it.advance();
+        assertEquals(2, it.currentIndex());
+        assertEquals(Itinerary.State.DONE, it.state());
+    }
+
+    @Test
+    @DisplayName("should be done when all waypoints visited")
+    void doneWhenAllVisited() {
+        Itinerary it = new Itinerary();
+        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 1, List.of()));
+        it.addWaypoint(new Waypoint(Waypoint.Type.STATION, 2, List.of()));
+
+        it.advance();
+        it.advance();
+        assertEquals(Itinerary.State.DONE, it.state());
+    }
+
+    @Test
+    @DisplayName("should return current waypoint")
+    void currentWaypoint() {
+        Itinerary it = new Itinerary();
+        Waypoint wp1 = new Waypoint(Waypoint.Type.STATION, 1, List.of());
+        Waypoint wp2 = new Waypoint(Waypoint.Type.STATION, 2, List.of());
+        it.addWaypoint(wp1);
+        it.addWaypoint(wp2);
+
+        assertEquals(wp1, it.currentWaypoint().orElse(null));
+        it.advance();
+        assertEquals(wp2, it.currentWaypoint().orElse(null));
+    }
+
+    @Test
+    @DisplayName("should allow assigning to multiple trains")
+    void multipleTrains() {
+        Itinerary it = new Itinerary();
+        it.assignTrain(1);
+        it.assignTrain(2);
+        it.assignTrain(3);
+
+        assertTrue(it.assignedTrains().contains(1));
+        assertTrue(it.assignedTrains().contains(2));
+        assertTrue(it.assignedTrains().contains(3));
+        assertEquals(3, it.assignedTrains().size());
+    }
+
+    @Test
+    @DisplayName("should allow unassigning trains")
+    void unassignTrain() {
+        Itinerary it = new Itinerary();
+        it.assignTrain(1);
+        it.assignTrain(2);
+        it.unassignTrain(1);
+
+        assertFalse(it.assignedTrains().contains(1));
+        assertTrue(it.assignedTrains().contains(2));
+    }
+}

--- a/src/test/java/letrain/itinerary/WaypointCommandTest.java
+++ b/src/test/java/letrain/itinerary/WaypointCommandTest.java
@@ -1,0 +1,50 @@
+package letrain.itinerary;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("WaypointCommand")
+class WaypointCommandTest {
+
+    @Test
+    @DisplayName("should have load and unload commands")
+    void loadUnload() {
+        assertEquals(WaypointCommand.Kind.LOAD, WaypointCommand.LOAD.kind());
+        assertEquals(WaypointCommand.Kind.UNLOAD, WaypointCommand.UNLOAD.kind());
+    }
+
+    @Test
+    @DisplayName("should have reverse command with no ticks")
+    void reverseHasNoTicks() {
+        assertEquals(0, WaypointCommand.REVERSE.ticks());
+    }
+
+    @Test
+    @DisplayName("WAIT should store ticks")
+    void waitStoresTicks() {
+        WaypointCommand wait = WaypointCommand.waitTicks(300);
+        assertEquals(300, wait.ticks());
+    }
+
+    @Test
+    @DisplayName("SPEED should store target speed")
+    void speedStoresTarget() {
+        WaypointCommand speed = WaypointCommand.speed(5);
+        assertEquals(5, speed.targetSpeed());
+    }
+
+    @Test
+    @DisplayName("NONE should have no parameters")
+    void noneHasNoParams() {
+        assertEquals(0, WaypointCommand.NONE.ticks());
+        assertEquals(0, WaypointCommand.NONE.targetSpeed());
+    }
+
+    @Test
+    @DisplayName("should identify REVERSE command")
+    void isReverse() {
+        assertTrue(WaypointCommand.REVERSE.isReverse());
+        assertFalse(WaypointCommand.LOAD.isReverse());
+    }
+}

--- a/src/test/java/letrain/itinerary/WaypointTest.java
+++ b/src/test/java/letrain/itinerary/WaypointTest.java
@@ -1,5 +1,6 @@
 package letrain.itinerary;
 
+import letrain.itinerary.impl.WaypointImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,7 +13,7 @@ class WaypointTest {
     @Test
     @DisplayName("should create station waypoint with id")
     void stationWaypoint() {
-        Waypoint wp = new Waypoint(Waypoint.Type.STATION, 3, List.of(WaypointCommand.LOAD));
+        Waypoint wp = new WaypointImpl(Waypoint.Type.STATION, 3, List.of(WaypointCommand.LOAD));
 
         assertEquals(Waypoint.Type.STATION, wp.type());
         assertEquals(3, wp.targetId());
@@ -22,7 +23,7 @@ class WaypointTest {
     @Test
     @DisplayName("should create sensor waypoint without commands")
     void sensorWaypoint() {
-        Waypoint wp = new Waypoint(Waypoint.Type.SENSOR, 7, List.of());
+        Waypoint wp = new WaypointImpl(Waypoint.Type.SENSOR, 7, List.of());
 
         assertEquals(Waypoint.Type.SENSOR, wp.type());
         assertEquals(7, wp.targetId());
@@ -32,7 +33,7 @@ class WaypointTest {
     @Test
     @DisplayName("should allow optional entry direction")
     void withEntryDir() {
-        Waypoint wp = new Waypoint(Waypoint.Type.STATION, 5, letrain.map.Dir.SW, List.of());
+        Waypoint wp = new WaypointImpl(Waypoint.Type.STATION, 5, letrain.map.Dir.SW, List.of());
 
         assertEquals(letrain.map.Dir.SW, wp.entryDir().orElse(null));
     }
@@ -40,7 +41,7 @@ class WaypointTest {
     @Test
     @DisplayName("should have empty entryDir when not specified")
     void withoutEntryDir() {
-        Waypoint wp = new Waypoint(Waypoint.Type.STATION, 5, List.of());
+        Waypoint wp = new WaypointImpl(Waypoint.Type.STATION, 5, List.of());
 
         assertTrue(wp.entryDir().isEmpty());
     }
@@ -48,7 +49,7 @@ class WaypointTest {
     @Test
     @DisplayName("should allow REVERSE command on sensor waypoint")
     void sensorWithReverse() {
-        Waypoint wp = new Waypoint(Waypoint.Type.SENSOR, 2, List.of(WaypointCommand.REVERSE));
+        Waypoint wp = new WaypointImpl(Waypoint.Type.SENSOR, 2, List.of(WaypointCommand.REVERSE));
 
         assertTrue(wp.commands().contains(WaypointCommand.REVERSE));
     }
@@ -56,7 +57,7 @@ class WaypointTest {
     @Test
     @DisplayName("should allow WAIT with ticks")
     void withWaitCommand() {
-        Waypoint wp = new Waypoint(Waypoint.Type.SENSOR, 1, List.of(WaypointCommand.waitTicks(300)));
+        Waypoint wp = new WaypointImpl(Waypoint.Type.SENSOR, 1, List.of(WaypointCommand.waitTicks(300)));
 
         assertEquals(300, wp.commands().get(0).ticks());
     }

--- a/src/test/java/letrain/itinerary/WaypointTest.java
+++ b/src/test/java/letrain/itinerary/WaypointTest.java
@@ -1,0 +1,63 @@
+package letrain.itinerary;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+@DisplayName("Waypoint")
+class WaypointTest {
+
+    @Test
+    @DisplayName("should create station waypoint with id")
+    void stationWaypoint() {
+        Waypoint wp = new Waypoint(Waypoint.Type.STATION, 3, List.of(WaypointCommand.LOAD));
+
+        assertEquals(Waypoint.Type.STATION, wp.type());
+        assertEquals(3, wp.targetId());
+        assertEquals(List.of(WaypointCommand.LOAD), wp.commands());
+    }
+
+    @Test
+    @DisplayName("should create sensor waypoint without commands")
+    void sensorWaypoint() {
+        Waypoint wp = new Waypoint(Waypoint.Type.SENSOR, 7, List.of());
+
+        assertEquals(Waypoint.Type.SENSOR, wp.type());
+        assertEquals(7, wp.targetId());
+        assertTrue(wp.commands().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should allow optional entry direction")
+    void withEntryDir() {
+        Waypoint wp = new Waypoint(Waypoint.Type.STATION, 5, letrain.map.Dir.SW, List.of());
+
+        assertEquals(letrain.map.Dir.SW, wp.entryDir().orElse(null));
+    }
+
+    @Test
+    @DisplayName("should have empty entryDir when not specified")
+    void withoutEntryDir() {
+        Waypoint wp = new Waypoint(Waypoint.Type.STATION, 5, List.of());
+
+        assertTrue(wp.entryDir().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should allow REVERSE command on sensor waypoint")
+    void sensorWithReverse() {
+        Waypoint wp = new Waypoint(Waypoint.Type.SENSOR, 2, List.of(WaypointCommand.REVERSE));
+
+        assertTrue(wp.commands().contains(WaypointCommand.REVERSE));
+    }
+
+    @Test
+    @DisplayName("should allow WAIT with ticks")
+    void withWaitCommand() {
+        Waypoint wp = new Waypoint(Waypoint.Type.SENSOR, 1, List.of(WaypointCommand.waitTicks(300)));
+
+        assertEquals(300, wp.commands().get(0).ticks());
+    }
+}


### PR DESCRIPTION
## Fase 1 — TDD: Estructuras de datos del itinerario

Define el contrato vía tests. Implementación mínima para compilar.

### Nuevas clases (`letrain.itinerary`)
- `Waypoint` — record con tipo (STATION/SENSOR), targetId, entryDir opcional, comandos
- `WaypointCommand` — LOAD, UNLOAD, REVERSE, WAIT(ticks), SPEED(n), NONE
- `Itinerary` — lista de waypoints, estado (CREATED/ACTIVE/PAUSED/DONE), asignación N:1 de trenes

### Tests (21 nuevos)
| Clase | Tests | Qué cubre |
|-------|-------|-----------|
| `WaypointTest` | 6 | Construcción, entryDir, comandos |
| `WaypointCommandTest` | 6 | Tipos, parámetros, isReverse |
| `ItineraryTest` | 9 | CRUD, validación, advance, asignación |

### Build
```
Tests run: 287, Failures: 0
```

### Siguiente fase
Implementar `SegmentPathfinder` (A*) y validación de alcanzabilidad.

Closes #149