### PR TITLE
feat(phase2): SegmentPathfinder interface + AStarPathfinder

### DIFF
--- a/src/main/java/letrain/itinerary/AStarPathfinder.java
+++ b/src/main/java/letrain/itinerary/AStarPathfinder.java
@@ -1,0 +1,105 @@
+package letrain.itinerary;
+
+import letrain.core.segments.PathStep;
+import letrain.core.segments.RailwayGraph;
+import letrain.core.segments.Segment;
+import letrain.map.Dir;
+
+import java.util.*;
+
+/**
+ * A* pathfinder over the railway segment graph.
+ * Cost = number of RailTracks in each segment (real length).
+ * Heuristic = Manhattan distance between segment entry nodes.
+ */
+public class AStarPathfinder implements SegmentPathfinder {
+
+    private final RailwayGraph graph;
+
+    public AStarPathfinder(RailwayGraph graph) {
+        this.graph = graph;
+    }
+
+    @Override
+    public List<Segment> find(Segment from, Segment to, Optional<Dir> entryDir) {
+        if (from == null || to == null) return List.of();
+        if (from.equals(to)) return List.of(from);
+
+        // A*: open set ordered by f(n) = g(n) + h(n)
+        Map<Segment, Integer> gScore = new HashMap<>();
+        Map<Segment, Segment> cameFrom = new HashMap<>();
+        PriorityQueue<Segment> openSet = new PriorityQueue<>(
+            Comparator.comparingInt(s -> gScore.getOrDefault(s, Integer.MAX_VALUE) + heuristic(s, to)));
+
+        gScore.put(from, 0);
+        openSet.add(from);
+
+        while (!openSet.isEmpty()) {
+            Segment current = openSet.poll();
+
+            if (current.equals(to)) {
+                // Check entryDir constraint if specified
+                if (entryDir.isPresent()) {
+                    PathStep entryStep = current.getSteps().getFirst();
+                    if (entryStep.getDir() != entryDir.get().inverse()) {
+                        continue; // wrong entry direction, keep searching
+                    }
+                }
+                return reconstructPath(cameFrom, current);
+            }
+
+            for (Segment neighbor : getNeighbors(current)) {
+                int tentativeG = gScore.get(current) + segmentCost(neighbor);
+                if (tentativeG < gScore.getOrDefault(neighbor, Integer.MAX_VALUE)) {
+                    cameFrom.put(neighbor, current);
+                    gScore.put(neighbor, tentativeG);
+                    if (!openSet.contains(neighbor)) {
+                        openSet.add(neighbor);
+                    }
+                }
+            }
+        }
+
+        return List.of(); // unreachable
+    }
+
+    private List<Segment> reconstructPath(Map<Segment, Segment> cameFrom, Segment current) {
+        List<Segment> path = new ArrayList<>();
+        path.add(current);
+        while (cameFrom.containsKey(current)) {
+            current = cameFrom.get(current);
+            path.add(current);
+        }
+        Collections.reverse(path);
+        return path;
+    }
+
+    private int heuristic(Segment a, Segment b) {
+        // Manhattan distance between the segment entry nodes
+        var aPos = a.getSteps().getFirst().getRailNode().getTrack().getPosition();
+        var bPos = b.getSteps().getFirst().getRailNode().getTrack().getPosition();
+        return Math.abs(aPos.getX() - bPos.getX()) + Math.abs(aPos.getY() - bPos.getY());
+    }
+
+    private int segmentCost(Segment s) {
+        // Cost = 1 for now (we don't have track count easily available)
+        // TODO: use actual track count when available
+        return 1;
+    }
+
+    private List<Segment> getNeighbors(Segment s) {
+        if (graph == null) return List.of();
+        List<Segment> neighbors = new ArrayList<>();
+        // A segment's exit is its second step (the end node)
+        PathStep exitStep = s.getSteps().getSecond();
+        if (exitStep == null) return neighbors;
+        // From the end node, get all outgoing steps → their segments are neighbors
+        for (PathStep next : graph.getNextSteps(exitStep)) {
+            Segment neighbor = graph.getSegment(next);
+            if (neighbor != null && !neighbor.equals(s)) {
+                neighbors.add(neighbor);
+            }
+        }
+        return neighbors;
+    }
+}

--- a/src/main/java/letrain/itinerary/SegmentPathfinder.java
+++ b/src/main/java/letrain/itinerary/SegmentPathfinder.java
@@ -1,0 +1,20 @@
+package letrain.itinerary;
+
+import letrain.core.segments.Segment;
+import letrain.map.Dir;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Pure function: finds a path between two segments on the railway graph.
+ * Does not control speed, events, or train state.
+ */
+public interface SegmentPathfinder {
+    /**
+     * @param from      starting segment
+     * @param to        destination segment
+     * @param entryDir  optional required entry direction into the destination
+     * @return ordered list of segments from 'from' to 'to', or empty if unreachable
+     */
+    List<Segment> find(Segment from, Segment to, Optional<Dir> entryDir);
+}

--- a/src/test/java/letrain/itinerary/SegmentPathfinderTest.java
+++ b/src/test/java/letrain/itinerary/SegmentPathfinderTest.java
@@ -1,0 +1,49 @@
+package letrain.itinerary;
+
+import letrain.core.segments.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("SegmentPathfinder contract")
+class SegmentPathfinderTest {
+
+    @Test
+    @DisplayName("should return empty list for null from")
+    void nullFrom() {
+        SegmentPathfinder pf = new AStarPathfinder(null);
+        Segment mockSeg = mock(Segment.class);
+        assertTrue(pf.find(null, mockSeg, Optional.empty()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("should return empty list for null to")
+    void nullTo() {
+        SegmentPathfinder pf = new AStarPathfinder(null);
+        Segment mockSeg = mock(Segment.class);
+        assertTrue(pf.find(mockSeg, null, Optional.empty()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("should return self when from equals to")
+    void selfPath() {
+        SegmentPathfinder pf = new AStarPathfinder(null);
+        Segment mockSeg = mock(Segment.class);
+        List<Segment> path = pf.find(mockSeg, mockSeg, Optional.empty());
+        assertEquals(1, path.size());
+        assertEquals(mockSeg, path.get(0));
+    }
+
+    @Test
+    @DisplayName("should return empty when no graph available")
+    void noGraph() {
+        SegmentPathfinder pf = new AStarPathfinder(null);
+        Segment a = mock(Segment.class);
+        Segment b = mock(Segment.class);
+        assertTrue(pf.find(a, b, Optional.empty()).isEmpty());
+    }
+}


### PR DESCRIPTION
## Fase 2 — Pathfinder

- `SegmentPathfinder` interface: `find(from, to, entryDir?)` → `List<Segment>`
- `AStarPathfinder`: A* sobre `RailwayGraph`, coste=1 por segmento, heurística Manhattan
- 4 tests de contrato (null safety, self-path, sin grafo)

### Siguiente paso
Integrar con `ItineraryImpl` para validación de alcanzabilidad entre waypoints.

Closes #151