### PR TITLE
fix(phase-a): robustez — null guards, casts seguros y cooldown en autopilot

### DIFF
--- a/src/main/java/letrain/command/CommandManager.java
+++ b/src/main/java/letrain/command/CommandManager.java
@@ -20,6 +20,7 @@ import letrain.track.SensorEventListener;
 import letrain.track.Station;
 import letrain.track.StationEventListener;
 import letrain.track.rail.ForkRailTrack;
+import letrain.vehicle.impl.Tractor;
 import letrain.vehicle.impl.rail.Locomotive;
 import letrain.vehicle.impl.rail.Train;
 import org.slf4j.Logger;
@@ -371,22 +372,37 @@ public class CommandManager extends LeTrainProgramBaseVisitor<Object> {
         if (ctx.trainSpeed() != null) {
             int speed = Integer.parseInt(ctx.trainSpeed().getText());
             int clampedSpeed = Math.max(0, Math.min(10, speed));
-            return (t) -> ((Locomotive) t.getDirectorLinker()).setSpeed(clampedSpeed);
+            return (t) -> {
+                Tractor tractor = t.getDirectorLinker();
+                if (tractor != null) tractor.setSpeed(clampedSpeed);
+            };
         } else if (actionText.contains("accelerate")) {
-            return (t) -> ((Locomotive) t.getDirectorLinker()).incSpeed();
+            return (t) -> {
+                Tractor tractor = t.getDirectorLinker();
+                if (tractor != null) tractor.incSpeed();
+            };
         } else if (actionText.contains("decelerate")) {
-            return (t) -> ((Locomotive) t.getDirectorLinker()).decSpeed();
+            return (t) -> {
+                Tractor tractor = t.getDirectorLinker();
+                if (tractor != null) tractor.decSpeed();
+            };
         } else if (ctx.trainSense() != null) {
             boolean forward = "forward".equals(ctx.trainSense().getText());
             return (t) -> {
-                Locomotive l = (Locomotive) t.getDirectorLinker();
-                if (l.isReversed() == forward)
-                    l.toggleReversed();
+                Tractor tractor = t.getDirectorLinker();
+                if (tractor != null && tractor.isReversed() == forward)
+                    tractor.toggleReversed();
             };
         } else if (actionText.contains("stop")) {
-            return (t) -> ((Locomotive) t.getDirectorLinker()).setSpeed(0);
+            return (t) -> {
+                Tractor tractor = t.getDirectorLinker();
+                if (tractor != null) tractor.setSpeed(0);
+            };
         } else if (actionText.contains("invert")) {
-            return (t) -> ((Locomotive) t.getDirectorLinker()).toggleReversed();
+            return (t) -> {
+                Tractor tractor = t.getDirectorLinker();
+                if (tractor != null) tractor.toggleReversed();
+            };
         } else if (ctx.linkAction() != null) {
             LeTrainProgramParser.LinkActionContext lCtx = ctx.linkAction();
             boolean forward = "forward".equals(lCtx.sense().getText());

--- a/src/main/java/letrain/itinerary/impl/AutoPilotImpl.java
+++ b/src/main/java/letrain/itinerary/impl/AutoPilotImpl.java
@@ -25,6 +25,9 @@ public class AutoPilotImpl implements AutoPilot {
     private SegmentPathfinder pathfinder;
     private List<Segment> currentRoute = List.of();
     private Segment lastSegment;
+    private int routeRetryCooldown = 0;
+
+    private static final int ROUTE_RETRY_TICKS = 100;
 
     private final AutoPilotContext ctx;
 
@@ -65,6 +68,7 @@ public class AutoPilotImpl implements AutoPilot {
         this.mode = Mode.IDLE;
         this.currentRoute = List.of();
         this.lastSegment = null;
+        this.routeRetryCooldown = 0;
     }
 
     @Override
@@ -78,6 +82,7 @@ public class AutoPilotImpl implements AutoPilot {
         mode = Mode.FOLLOWING;
         currentRoute = List.of();
         lastSegment = null;
+        routeRetryCooldown = 0;
         itinerary.reset();
         ctx.forceSegmentReset();
         log.info("[AP] activate → FOLLOWING");
@@ -142,9 +147,14 @@ public class AutoPilotImpl implements AutoPilot {
         }
 
         if (currentRoute.isEmpty()) {
+            if (routeRetryCooldown > 0) {
+                routeRetryCooldown--;
+                return false;
+            }
             log.info("[AP] calculating route to wp {}...", wp.targetId());
             if (!calculateRoute()) {
-                log.warn("[AP] calculateRoute failed, retrying next tick");
+                log.warn("[AP] calculateRoute failed, retrying in {} ticks", ROUTE_RETRY_TICKS);
+                routeRetryCooldown = ROUTE_RETRY_TICKS;
                 return false;
             }
         }

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -461,11 +461,8 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
     }
 
     public void assignDefaultDirectorLinker() {
-        setDirectorLinker(getTractors() != null
-                &&
-                !getTractors().isEmpty()
-                        ? (Tractor) getTractors().get(0)
-                        : null);
+        List<Tractor> tractors = getTractors();
+        setDirectorLinker(tractors.isEmpty() ? null : tractors.get(0));
     }
 
     @Override
@@ -496,9 +493,9 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable {
     @com.fasterxml.jackson.annotation.JsonIgnore
     public List<Tractor> getTractors() {
         return linkers.stream()
-                .filter(t -> Tractor.class.isAssignableFrom(t.getClass()))
-                .map(t -> (Tractor) t)
-                .collect(Collectors.toList());
+                .filter(l -> l instanceof Tractor)
+                .map(l -> (Tractor) l)
+                .toList();
     }
 
     /**

--- a/src/main/java/letrain/vehicle/impl/rail/Trip.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Trip.java
@@ -25,7 +25,7 @@ public class Trip {
     }
 
     public void setStops(List<Stop> stops) {
-        this.stops = stops;
+        this.stops = stops != null ? stops : new ArrayList<>();
     }
 
     public void setState(TripState state) {
@@ -41,6 +41,9 @@ public class Trip {
     }
 
     public void addStop(Stop stop) {
+        if (stops == null) {
+            stops = new ArrayList<>();
+        }
         if (getStops()
                 .map(Stop::stationId)
                 .filter(t -> t == stop.stationId())
@@ -74,6 +77,9 @@ public class Trip {
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     public Stream<Stop> getStops() {
+        if (stops == null) {
+            stops = new ArrayList<>();
+        }
         return stops.stream();
     }
 

--- a/src/test/java/letrain/itinerary/AutoPilotImplTest.java
+++ b/src/test/java/letrain/itinerary/AutoPilotImplTest.java
@@ -128,10 +128,35 @@ class AutoPilotImplTest {
         assertEquals(List.of(segA, segB), autopilot.currentRoute());
     }
 
+
     @Test
     @DisplayName("should deactivate cleanly")
     void deactivatesCleanly() {
         autopilot.deactivate();
         assertEquals(AutoPilot.Mode.IDLE, autopilot.mode());
+    }
+
+    @Test
+    @DisplayName("should not call pathfinder on every tick after a route failure (cooldown)")
+    void routeFailureCooldownSuppressesRetries() {
+        when(ctx.currentSpeed()).thenReturn(0);
+        when(ctx.currentSegment()).thenReturn(segA);
+        when(ctx.targetSegment(any())).thenReturn(segB);
+        when(ctx.isAtTarget(any())).thenReturn(false);
+        when(pathfinder.find(any(), any(), any())).thenReturn(List.of());
+
+        autopilot.setItinerary(itinerary);
+        autopilot.activate();
+
+        // First tick: route fails, cooldown starts
+        assertFalse(autopilot.tick());
+
+        // Next ticks within cooldown window: pathfinder must NOT be called again
+        autopilot.tick();
+        autopilot.tick();
+
+        // pathfinder was called exactly once (on the first tick)
+        org.mockito.Mockito.verify(pathfinder, org.mockito.Mockito.times(1))
+                .find(any(), any(), any());
     }
 }

--- a/src/test/java/letrain/vehicle/impl/rail/TripTest.java
+++ b/src/test/java/letrain/vehicle/impl/rail/TripTest.java
@@ -69,4 +69,37 @@ class TripTest {
         assertEquals(newStartStop, stops.get(0));
         assertEquals(Trip.TripState.STARTING, trip.getState());
     }
+
+    @Test
+    @DisplayName("setStops(null) should be treated as empty list — no NPE")
+    void should_TreatNullStopsAsEmpty_When_SetViaSetStops() {
+        // Arrange: simulate Jackson deserialization writing null
+        Trip trip = new Trip();
+        trip.setStops(null);
+
+        // Act & Assert: no NPE when getting or adding
+        assertEquals(0, trip.getStopsList().size());
+        assertNotNull(trip.getStops());
+
+        Stop stop = new Stop(1, LocalDateTime.now(), 0);
+        trip.addStop(stop); // must not throw
+        assertEquals(1, trip.getStopsList().size());
+    }
+
+    @Test
+    @DisplayName("addStop should be safe when internal stops is null")
+    void should_HandleNullInternalStops_When_AddStop() {
+        // Arrange: use setStops(null) to force stops=null, then bypass the setter
+        // by relying on the null-check inside addStop itself
+        Trip trip = new Trip();
+        trip.setStops(null);
+
+        // Act
+        Stop stop = new Stop(5, LocalDateTime.now(), 10);
+        trip.addStop(stop);
+
+        // Assert
+        assertEquals(Trip.TripState.STARTING, trip.getState());
+        assertEquals(1, trip.getStopsList().size());
+    }
 }


### PR DESCRIPTION
## Resumen

Correcciones de los tres errores críticos identificados en el análisis de la Fase A del sistema de itinerarios y autopilot.

## Cambios

### `CommandManager.java` — Casts inseguros a `Locomotive`
- En `buildTrainAction(...)`, los callbacks casteaban `t.getDirectorLinker()` directamente a `(Locomotive)` sin comprobación de tipo ni guard de null.
- La interfaz `Tractor` ya expone `setSpeed`, `incSpeed`, `decSpeed`, `isReversed` y `toggleReversed`, así que el cast era redundante y peligroso.
- Se sustituyen todos los casts por llamadas directas a `Tractor` con null check.

### `Trip.java` — Vulnerabilidad NPE por deserialización Jackson
- Cuando Jackson deserializa un `Trip` con el campo `stops` ausente o null, el campo interno quedaba a null.
- `setStops(null)` ahora normaliza a lista vacía; `addStop` y `getStops` inicializan la lista si es null.

### `AutoPilotImpl.java` — Tormenta A* cuando el cálculo de ruta falla
- Si `calculateRoute()` fallaba, el autopilot reintentaba el pathfinding A* en **cada tick** (hasta 60 veces/segundo), lo que degrada el rendimiento en mapas complejos.
- Se introduce `routeRetryCooldown` (100 ticks ≈ 5s): tras un fallo, el autopilot espera antes de reintentar.
- El cooldown se resetea al activar el autopilot o al asignar un nuevo itinerario.

### `Train.java` — Limpieza de código
- `assignDefaultDirectorLinker`: eliminar cast redundante a `(Tractor)`.
- `getTractors()`: sustituir reflexión verbose por `instanceof` idiomático y `toList()`.

## Tests
- Nuevo test en `AutoPilotImplTest`: verifica que el pathfinder no se invoca en cada tick tras un fallo de ruta (cooldown).
- 2 nuevos tests en `TripTest`: verifican comportamiento null-safe en `setStops(null)` y `addStop` con stops null.
- **324 tests pasan** (321 anteriores + 3 nuevos).

## Verificación
```
mvn clean test → BUILD SUCCESS (324 tests, 0 failures)
```