### PR TITLE
refactor: decouple action methods from AutoPilotContext to TrainActionManager

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -1,67 +1,87 @@
-# Implementation Plan - Phase B Part 2: Pathfinder & Test Cleanup
+# Implementation Plan - Decouple Actions from AutoPilotContext
 
-This plan describes the proposed changes to align the segment pathfinder (`AStarPathfinder`) with the design specified in ADR-008, and clean up the `AutoPilot` test suite by removing the redundant `AutoPilotStub` and making `AutoPilotTest` verify the real implementation.
+This plan details the refactoring to separate read-only queries from action/mutation operations in the Autopilot module. Specifically, we will migrate actions from `AutoPilotContext` (and its implementation `TrainAutoPilotContext`) to `TrainActionManager` (implemented by `Train`), leaving `AutoPilotContext` as a clean, read-only interface.
 
 ## User Review Required
 
 > [!NOTE]
-> All changes are backward-compatible and do not change public APIs.
-> We add a new default method `getTrackCount(Segment segment)` to the `RailwayGraph` interface, returning `0` by default. This avoids breaking existing mocks.
+> All changes are backward-compatible. `Train` already implements `TrainActionManager`, so adding the action methods there is highly aligned with its existing role.
+> The tests will be updated to verify action execution on the `TrainActionManager` mock instead of the context mock.
 
 ---
 
 ## Proposed Changes
 
-### Navigation & Graph
+### Navigation & Autopilot Interfaces
 
-#### [MODIFY] [RailwayGraph.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/segments/RailwayGraph.java)
-- Add a new default method:
-  ```java
-  default int getTrackCount(Segment segment) {
-      return 0;
-  }
-  ```
+#### [MODIFY] [AutoPilotContext.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/AutoPilotContext.java)
+- Remove action/mutation method declarations:
+  - `void ensureForkRoute(Segment from, Segment to);`
+  - `void notifySegmentOccupied(Segment segment);`
+  - `void forceSegmentReset();`
+- This leaves the context with only read-only/query methods.
 
-#### [MODIFY] [RailwayGraphImpl.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/segments/impl/RailwayGraphImpl.java)
-- Add a tracking map for segment tracks:
-  ```java
-  private final Map<Segment, Set<letrain.track.rail.RailTrack>> segmentToTracks = new HashMap<>();
-  ```
-- Update `registerTrack(Segment segment, RailTrack track)` to populate `segmentToTracks`:
-  ```java
-  public void registerTrack(Segment segment, letrain.track.rail.RailTrack track) {
-      trackToSegment.putIfAbsent(track, segment);
-      segmentToTracks.computeIfAbsent(segment, k -> new HashSet<>()).add(track);
-  }
-  ```
-- Override `getTrackCount(Segment segment)` to return the size of the set from `segmentToTracks`.
+#### [MODIFY] [TrainActionManager.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/TrainActionManager.java)
+- Add the action method declarations removed from `AutoPilotContext`:
+  - `void ensureForkRoute(letrain.segments.Segment from, letrain.segments.Segment to);`
+  - `void notifySegmentOccupied(letrain.segments.Segment segment);`
+  - `void forceSegmentReset();`
 
-#### [MODIFY] [AStarPathfinder.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/AStarPathfinder.java)
-- Implement `segmentCost(Segment s)` to use the actual physical track count:
-  ```java
-  private int segmentCost(Segment s) {
-      int count = graph.getTrackCount(s);
-      return count > 0 ? count : 1;
-  }
-  ```
-- Restore the `entryDir` check. In the neighbor iteration, if `neighbor.equals(to)` and `entryDir.isPresent()`, find the `PathStep` representing the transition from the current segment to the neighbor segment. If the direction of the transition step (`next.getDir()`) does not match `entryDir.get()`, discard the neighbor.
+---
 
-### Autopilot & Tests
+### Implementation Classes
 
-#### [MODIFY] [AutoPilotTest.java](file:///home/antonio/dev/LeTrain/src/test/java/letrain/itinerary/AutoPilotTest.java)
-- Remove import and instantiation of `AutoPilotStub`.
-- Mock `AutoPilotContext` using Mockito.
-- Instantiate `AutoPilotImpl` and verify the test assertions directly against the real implementation.
+#### [MODIFY] [TrainAutoPilotContext.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/impl/rail/TrainAutoPilotContext.java)
+- Remove overridden implementations of the 3 action methods:
+  - `ensureForkRoute(Segment from, Segment to)`
+  - `notifySegmentOccupied(Segment segment)`
+  - `forceSegmentReset()`
+- Remove the private helper method `isAlternativeRouteNeeded(ForkRailTrack fork, letrain.map.Dir targetDir)`.
 
-#### [DELETE] [AutoPilotStub.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/impl/AutoPilotStub.java)
-- Delete the redundant stub class.
+#### [MODIFY] [Train.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/impl/rail/Train.java)
+- Import:
+  - `letrain.segments.Segment`
+  - `letrain.segments.RailwayGraph`
+  - `letrain.segments.RailNode`
+  - `letrain.track.rail.ForkRailTrack`
+- Add `@Override` to the existing methods:
+  - `public void forceSegmentReset()`
+  - `public void notifySegmentOccupied(letrain.segments.Segment segment)`
+- Implement `public void ensureForkRoute(Segment from, Segment to)` containing the logic moved from `TrainAutoPilotContext.java`.
+- Implement `private boolean isAlternativeRouteNeeded(ForkRailTrack fork, letrain.map.Dir targetDir)` helper in `Train.java`.
+
+#### [MODIFY] [AutoPilotImpl.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/impl/AutoPilotImpl.java)
+- Update code to call actions on `actionManager` (with null checks) instead of `ctx`:
+  - In `activate()`:
+    ```java
+    if (actionManager != null) {
+        actionManager.forceSegmentReset();
+    }
+    ```
+  - In `ensureForkRoute(Segment from, Segment to)`:
+    ```java
+    if (actionManager != null) {
+        actionManager.ensureForkRoute(from, to);
+    }
+    ```
+  - In `tick()` when next segment is occupied:
+    ```java
+    if (actionManager != null) {
+        actionManager.notifySegmentOccupied(nextSeg);
+    }
+    ```
+
+---
+
+### Tests
+
+#### [MODIFY] [AutoPilotImplTest.java](file:///home/antonio/dev/LeTrain/src/test/java/letrain/itinerary/AutoPilotImplTest.java)
+- Update `setUp()` to mock `TrainActionManager` and pass it to the constructor of `AutoPilotImpl`.
+- Update verifications to assert action calls (`ensureForkRoute`, `notifySegmentOccupied`) on the `actionManager` mock rather than on `ctx`.
 
 ---
 
 ## Verification Plan
 
 ### Automated Tests
-- Run `mvn clean test` to verify all 326 tests pass successfully.
-- Write new unit tests in [SegmentPathfinderTest.java](file:///home/antonio/dev/LeTrain/src/test/java/letrain/itinerary/SegmentPathfinderTest.java) to verify:
-  1. That the pathfinder correctly calculates costs using track counts.
-  2. That the `entryDir` constraint successfully filters out paths entering from incorrect directions.
+- Run `mvn clean test` to compile and verify all unit and integration tests.

--- a/docs/task.md
+++ b/docs/task.md
@@ -1,10 +1,12 @@
-# Task — Pathfinder & Test Cleanup (Phase B Part 2)
+# Task — Decouple Actions from AutoPilotContext
 
-Align AStarPathfinder with ADR-008 segment costs and entryDir constraints, and clean up the AutoPilot test suite.
+Move action/mutation methods from `AutoPilotContext` to `TrainActionManager`, implement them in `Train`, update `AutoPilotImpl`, and adapt test cases.
 
-- [x] Implement physical track count tracking in `RailwayGraph` / `RailwayGraphImpl`
-- [x] Refactor `AStarPathfinder.java` to use segment track count for edge costs
-- [x] Restore and implement `entryDir` constraint check in `AStarPathfinder.java`
-- [x] Refactor `AutoPilotTest.java` to verify `AutoPilotImpl` directly and delete `AutoPilotStub.java`
-- [x] Write new unit tests in `SegmentPathfinderTest.java` verifying pathfinder cost and entryDir logic
-- [x] Run `mvn clean test` to ensure all tests pass
+- [x] Create git branch `feature/autopilot-actions-refactor`
+- [x] Modify `AutoPilotContext.java` to remove action declarations
+- [x] Modify `TrainActionManager.java` to add action declarations
+- [x] Modify `TrainAutoPilotContext.java` to remove action implementations
+- [x] Modify `Train.java` to implement `ensureForkRoute` and annotate action overrides
+- [x] Modify `AutoPilotImpl.java` to execute actions via `actionManager`
+- [x] Update `AutoPilotImplTest.java` to mock and verify actions on `TrainActionManager`
+- [x] Run `mvn clean test` to verify all tests compile and pass successfully

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,49 +1,30 @@
-# Walkthrough - Pathfinder & Test Cleanup (Phase B Part 2)
+# Walkthrough - Decouple Actions from AutoPilotContext
 
-We have successfully aligned the segment pathfinder (`AStarPathfinder`) with ADR-008, updated the test suite to verify the real autopilot class, and discarded the redundant test stub.
+We successfully refactored `AutoPilotContext` to make it a strictly read-only interface containing queries. All action/mutation operations have been migrated to the `TrainActionManager` interface.
 
 ## Changes Made
 
-### 1. Physical Segment Cost Tracking
-* **Files:**
-  - [RailwayGraph.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/segments/RailwayGraph.java)
-  - [RailwayGraphImpl.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/segments/impl/RailwayGraphImpl.java)
-* **Design:**
-  - Added a new default method `getTrackCount(Segment segment)` to the `RailwayGraph` interface, which returns `0` by default.
-  - Implemented set-based tracking of tracks per segment in `RailwayGraphImpl` via a new map `segmentToTracks`. Updated `registerTrack` to populate this map.
-  - Overrode `getTrackCount` to return the count of physical tracks associated with the segment.
+### 1. Navigation & Autopilot Interfaces
+- **[AutoPilotContext.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/AutoPilotContext.java)**: Removed `ensureForkRoute`, `notifySegmentOccupied`, and `forceSegmentReset`.
+- **[TrainActionManager.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/TrainActionManager.java)**: Added the signatures for `ensureForkRoute`, `notifySegmentOccupied`, and `forceSegmentReset`.
 
-### 2. Physical Cost & Entry Direction in A*
-* **File:** [AStarPathfinder.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/AStarPathfinder.java)
-* **Design:**
-  - Updated `segmentCost(Segment s)` to retrieve the track count using `graph.getTrackCount(s)`. This ensures edge weights in A* correspond to actual track lengths instead of a flat cost of 1.
-  - Restored and implemented the `entryDir` constraint check. When transitioning from the current segment to the target segment `to`, we verify that the transition step direction (`next.getDir()`) matches the specified `entryDir`. If not, the transition is skipped.
+### 2. Implementations
+- **[TrainAutoPilotContext.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/impl/rail/TrainAutoPilotContext.java)**: Removed implementation of the action methods and the helper `isAlternativeRouteNeeded`.
+- **[Train.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/impl/rail/Train.java)**: 
+  - Added `@Override` to `forceSegmentReset` and `notifySegmentOccupied`.
+  - Implemented `ensureForkRoute` (moved from `TrainAutoPilotContext`).
+  - Added the helper `isAlternativeRouteNeeded`.
+- **[AutoPilotImpl.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/impl/AutoPilotImpl.java)**: Updated to execute the actions (`forceSegmentReset`, `ensureForkRoute`, and `notifySegmentOccupied`) on `actionManager` (with null-safety checks) rather than `ctx`.
 
-### 3. Autopilot Test Suite Refactoring
-* **Files:**
-  - [AutoPilotTest.java](file:///home/antonio/dev/LeTrain/src/test/java/letrain/itinerary/AutoPilotTest.java)
-  - [AutoPilotStub.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/itinerary/impl/AutoPilotStub.java) [DELETED]
-* **Design:**
-  - Deleted `AutoPilotStub.java` to remove redundant/dead test code.
-  - Refactored `AutoPilotTest.java` to test the real implementation (`AutoPilotImpl`) using Mockito to mock `AutoPilotContext`.
-
-### 4. Pathfinder Enhancements Testing
-* **File:** [SegmentPathfinderTest.java](file:///home/antonio/dev/LeTrain/src/test/java/letrain/itinerary/SegmentPathfinderTest.java)
-* **Design:**
-  - Added a new unit test `physicalTrackCost` verifying that the pathfinder correctly chooses a path with fewer physical tracks even if it has the same number of segment transitions.
-  - Added a new unit test `entryDirConstraint` verifying that the pathfinder filters out paths that do not arrive in the requested `entryDir` direction, while still finding valid paths when the direction matches or is not specified.
+### 3. Tests
+- **[AutoPilotImplTest.java](file:///home/antonio/dev/LeTrain/src/test/java/letrain/itinerary/AutoPilotImplTest.java)**: Mocked `TrainActionManager` and updated assertions to verify that actions are correctly requested from the action manager rather than the read-only context.
 
 ---
 
-## Validation Results
+## Verification Results
 
-Running the full Maven clean and test cycle compiles cleanly and passes all 328 tests:
-
-```bash
-mvn clean test
-```
-
-### Output Summary
+### Automated Tests
+Ran `mvn clean test` successfully:
 ```
 [INFO] Results:
 [INFO]
@@ -53,4 +34,4 @@ mvn clean test
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
 ```
-All unit and integration tests are fully green.
+All 328 unit and integration tests compile and pass successfully.

--- a/src/main/java/letrain/itinerary/AutoPilotContext.java
+++ b/src/main/java/letrain/itinerary/AutoPilotContext.java
@@ -20,15 +20,6 @@ public interface AutoPilotContext {
     /** Is the given segment free (not occupied by another train)? */
     boolean isSegmentFree(Segment seg);
 
-    /** Ensure the fork between current and next segment is set correctly. */
-    void ensureForkRoute(Segment from, Segment to);
-
     /** Is the train at the target waypoint? */
     boolean isAtTarget(Waypoint wp);
-
-    /** Notify that a segment is occupied. */
-    void notifySegmentOccupied(Segment segment);
-
-    /** Force a segment entry reset in safety manager. */
-    void forceSegmentReset();
 }

--- a/src/main/java/letrain/itinerary/TrainActionManager.java
+++ b/src/main/java/letrain/itinerary/TrainActionManager.java
@@ -12,4 +12,13 @@ public interface TrainActionManager {
      * @param command the command to execute
      */
     void executeCommand(WaypointCommand command);
+
+    /** Ensure the fork between current and next segment is set correctly. */
+    void ensureForkRoute(letrain.segments.Segment from, letrain.segments.Segment to);
+
+    /** Notify that a segment is occupied. */
+    void notifySegmentOccupied(letrain.segments.Segment segment);
+
+    /** Force a segment entry reset in safety manager. */
+    void forceSegmentReset();
 }

--- a/src/main/java/letrain/itinerary/impl/AutoPilotImpl.java
+++ b/src/main/java/letrain/itinerary/impl/AutoPilotImpl.java
@@ -98,7 +98,9 @@ public class AutoPilotImpl implements AutoPilot {
         waitTicks = 0;
         pendingCommands.clear();
         itinerary.reset();
-        ctx.forceSegmentReset();
+        if (actionManager != null) {
+            actionManager.forceSegmentReset();
+        }
         log.info("[AP] activate → FOLLOWING");
         return true;
     }
@@ -112,7 +114,9 @@ public class AutoPilotImpl implements AutoPilot {
 
     @Override
     public void ensureForkRoute(Segment from, Segment to) {
-        ctx.ensureForkRoute(from, to);
+        if (actionManager != null) {
+            actionManager.ensureForkRoute(from, to);
+        }
     }
 
     @Override
@@ -247,11 +251,15 @@ public class AutoPilotImpl implements AutoPilot {
 
             if (index != -1 && index + 1 < currentRoute.size()) {
                 Segment nextSeg = currentRoute.get(index + 1);
-                ctx.ensureForkRoute(currentSeg, nextSeg);
+                if (actionManager != null) {
+                    actionManager.ensureForkRoute(currentSeg, nextSeg);
+                }
 
                 if (!ctx.isSegmentFree(nextSeg)) {
                     log.info("[AP] next segment {} is occupied, firing event", nextSeg.getId());
-                    ctx.notifySegmentOccupied(nextSeg);
+                    if (actionManager != null) {
+                        actionManager.notifySegmentOccupied(nextSeg);
+                    }
                 }
             }
         }

--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -31,6 +31,10 @@ import letrain.visitor.Renderable;
 import letrain.visitor.Visitor;
 import letrain.itinerary.TrainActionManager;
 import letrain.itinerary.WaypointCommand;
+import letrain.segments.Segment;
+import letrain.segments.RailwayGraph;
+import letrain.segments.RailNode;
+import letrain.track.rail.ForkRailTrack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,6 +103,7 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable, Tra
         safetyManager.resetSafetyTimer();
     }
 
+    @Override
     public void forceSegmentReset() {
         if (safetyManager != null) {
             safetyManager.forceSegmentReset();
@@ -246,6 +251,7 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable, Tra
         }
     }
 
+    @Override
     public void notifySegmentOccupied(letrain.segments.Segment segment) {
         if (trainListeners != null) {
             trainListeners.forEach(l -> l.onSegmentOccupied(this, segment));
@@ -956,5 +962,66 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable, Tra
             default:
                 break;
         }
+    }
+
+    @Override
+    public void ensureForkRoute(Segment from, Segment to) {
+        if (getModel() == null) return;
+        RailwayGraph graph = getModel().getRailwayGraph();
+        if (graph == null) return;
+
+        // Find the fork between 'from' and 'to' and set the correct route
+        var fromSteps = from.getSteps();
+        var toSteps = to.getSteps();
+        if (fromSteps == null || toSteps == null) return;
+
+        var f1 = fromSteps.getFirst();
+        var f2 = fromSteps.getSecond();
+        var t1 = toSteps.getFirst();
+        var t2 = toSteps.getSecond();
+
+        RailNode node = null;
+        if (f1 != null && f1.getRailNode() != null) {
+            var n1 = f1.getRailNode();
+            if ((t1 != null && n1.equals(t1.getRailNode())) || (t2 != null && n1.equals(t2.getRailNode()))) {
+                node = n1;
+            }
+        }
+        if (node == null && f2 != null && f2.getRailNode() != null) {
+            var n2 = f2.getRailNode();
+            if ((t1 != null && n2.equals(t1.getRailNode())) || (t2 != null && n2.equals(t2.getRailNode()))) {
+                node = n2;
+            }
+        }
+
+        if (node == null) {
+            log.warn("[FORK] ensureForkRoute {}->{}: no shared node found", from.getId(), to.getId());
+            return;
+        }
+        if (!(node.getTrack() instanceof ForkRailTrack fork)) {
+            log.debug("[FORK] ensureForkRoute {}->{}: shared node is not a fork ({})", from.getId(), to.getId(), node.getTrack());
+            return;
+        }
+
+        // Use the fork node's outSteps directly (getNextSteps goes to wrong node)
+        for (var step : node.getOutSteps()) {
+            Segment nextSeg = graph.getSegment(step);
+            log.debug("[FORK] ensureForkRoute {}->{}: outStep dir={} seg={}", from.getId(), to.getId(), step.getDir(), nextSeg != null ? nextSeg.getId() : "null");
+            if (nextSeg != null && nextSeg.equals(to)) {
+                boolean altNeeded = isAlternativeRouteNeeded(fork, step.getDir());
+                log.info("[FORK] ensureForkRoute {}->{}: MATCH fork={} altNeeded={} currentAlt={}", from.getId(), to.getId(), fork.getId(), altNeeded, fork.isUsingAlternativeRoute());
+                if (fork.isUsingAlternativeRoute() != altNeeded) {
+                    fork.flipRoute();
+                }
+                return;
+            }
+        }
+        log.warn("[FORK] ensureForkRoute {}->{}: no outStep leads to target seg", from.getId(), to.getId());
+    }
+
+    private boolean isAlternativeRouteNeeded(ForkRailTrack fork, letrain.map.Dir targetDir) {
+        // Check if the targetDir is the alternative route of the fork
+        var alt = fork.getRouter().getAlternativeRoute();
+        return alt != null && alt.getValue() == targetDir;
     }
 }

--- a/src/main/java/letrain/vehicle/impl/rail/TrainAutoPilotContext.java
+++ b/src/main/java/letrain/vehicle/impl/rail/TrainAutoPilotContext.java
@@ -64,66 +64,6 @@ public class TrainAutoPilotContext implements AutoPilotContext {
     }
 
     @Override
-    public void ensureForkRoute(Segment from, Segment to) {
-        if (train.getModel() == null) return;
-        RailwayGraph graph = train.getModel().getRailwayGraph();
-        if (graph == null) return;
-
-        // Find the fork between 'from' and 'to' and set the correct route
-        var fromSteps = from.getSteps();
-        var toSteps = to.getSteps();
-        if (fromSteps == null || toSteps == null) return;
-
-        var f1 = fromSteps.getFirst();
-        var f2 = fromSteps.getSecond();
-        var t1 = toSteps.getFirst();
-        var t2 = toSteps.getSecond();
-
-        RailNode node = null;
-        if (f1 != null && f1.getRailNode() != null) {
-            var n1 = f1.getRailNode();
-            if ((t1 != null && n1.equals(t1.getRailNode())) || (t2 != null && n1.equals(t2.getRailNode()))) {
-                node = n1;
-            }
-        }
-        if (node == null && f2 != null && f2.getRailNode() != null) {
-            var n2 = f2.getRailNode();
-            if ((t1 != null && n2.equals(t1.getRailNode())) || (t2 != null && n2.equals(t2.getRailNode()))) {
-                node = n2;
-            }
-        }
-
-        if (node == null) {
-            org.slf4j.LoggerFactory.getLogger(TrainAutoPilotContext.class)
-                .warn("[FORK] ensureForkRoute {}->{}: no shared node found", from.getId(), to.getId());
-            return;
-        }
-        if (!(node.getTrack() instanceof ForkRailTrack fork)) {
-            org.slf4j.LoggerFactory.getLogger(TrainAutoPilotContext.class)
-                .debug("[FORK] ensureForkRoute {}->{}: shared node is not a fork ({})", from.getId(), to.getId(), node.getTrack());
-            return;
-        }
-
-        // Use the fork node's outSteps directly (getNextSteps goes to wrong node)
-        for (var step : node.getOutSteps()) {
-            Segment nextSeg = graph.getSegment(step);
-            org.slf4j.LoggerFactory.getLogger(TrainAutoPilotContext.class)
-                .debug("[FORK] ensureForkRoute {}->{}: outStep dir={} seg={}", from.getId(), to.getId(), step.getDir(), nextSeg != null ? nextSeg.getId() : "null");
-            if (nextSeg != null && nextSeg.equals(to)) {
-                boolean altNeeded = isAlternativeRouteNeeded(fork, step.getDir());
-                org.slf4j.LoggerFactory.getLogger(TrainAutoPilotContext.class)
-                    .info("[FORK] ensureForkRoute {}->{}: MATCH fork={} altNeeded={} currentAlt={}", from.getId(), to.getId(), fork.getId(), altNeeded, fork.isUsingAlternativeRoute());
-                if (fork.isUsingAlternativeRoute() != altNeeded) {
-                    fork.flipRoute();
-                }
-                return;
-            }
-        }
-        org.slf4j.LoggerFactory.getLogger(TrainAutoPilotContext.class)
-            .warn("[FORK] ensureForkRoute {}->{}: no outStep leads to target seg", from.getId(), to.getId());
-    }
-
-    @Override
     public boolean isAtTarget(Waypoint wp) {
         if (train.getModel() == null) return false;
         switch (wp.type()) {
@@ -161,8 +101,6 @@ public class TrainAutoPilotContext implements AutoPilotContext {
         return false;
     }
 
-
-
     private Point findTargetPosition(Waypoint wp) {
         if (train.getModel() == null) return null;
         switch (wp.type()) {
@@ -174,21 +112,5 @@ public class TrainAutoPilotContext implements AutoPilotContext {
                 return sensor != null ? sensor.getPosition() : null;
         }
         return null;
-    }
-
-    @Override
-    public void forceSegmentReset() {
-        train.forceSegmentReset();
-    }
-
-    @Override
-    public void notifySegmentOccupied(Segment segment) {
-        train.notifySegmentOccupied(segment);
-    }
-
-    private boolean isAlternativeRouteNeeded(ForkRailTrack fork, letrain.map.Dir targetDir) {
-        // Check if the targetDir is the alternative route of the fork
-        var alt = fork.getRouter().getAlternativeRoute();
-        return alt != null && alt.getValue() == targetDir;
     }
 }

--- a/src/test/java/letrain/itinerary/AutoPilotImplTest.java
+++ b/src/test/java/letrain/itinerary/AutoPilotImplTest.java
@@ -24,6 +24,7 @@ class AutoPilotImplTest {
 
     private AutoPilot autopilot;
     private AutoPilotContext ctx;
+    private TrainActionManager actionManager;
     private SegmentPathfinder pathfinder;
     private Itinerary itinerary;
     private Segment segA, segB;
@@ -31,8 +32,9 @@ class AutoPilotImplTest {
     @BeforeEach
     void setUp() {
         ctx = mock(AutoPilotContext.class);
+        actionManager = mock(TrainActionManager.class);
         pathfinder = mock(SegmentPathfinder.class);
-        autopilot = new AutoPilotImpl(ctx);
+        autopilot = new AutoPilotImpl(ctx, actionManager);
         autopilot.setPathfinder(pathfinder);
 
         segA = mock(Segment.class);
@@ -75,7 +77,7 @@ class AutoPilotImplTest {
         autopilot.tick();
 
         verify(pathfinder).find(eq(segA), eq(segB), any());
-        verify(ctx).ensureForkRoute(segA, segB);
+        verify(actionManager).ensureForkRoute(segA, segB);
     }
 
     @Test
@@ -92,8 +94,8 @@ class AutoPilotImplTest {
         autopilot.activate();
         autopilot.tick();
 
-        verify(ctx).ensureForkRoute(segA, segB);
-        verify(ctx).notifySegmentOccupied(segB);
+        verify(actionManager).ensureForkRoute(segA, segB);
+        verify(actionManager).notifySegmentOccupied(segB);
     }
 
     @Test
@@ -190,6 +192,7 @@ class AutoPilotImplTest {
         autopilot.tick();
 
         // Assert
+        verify(actionManager).forceSegmentReset();
         verify(actionManager).executeCommand(cmdSpeed);
         verify(actionManager).executeCommand(cmdLoad);
         assertEquals(AutoPilot.Mode.FOLLOWING, autopilot.mode()); // Advanced to the next waypoint, still following
@@ -224,6 +227,7 @@ class AutoPilotImplTest {
 
         // Act & Assert 1: First tick arrives at target, executes STOP, hits WAIT, transitions to WAITING mode
         assertFalse(autopilot.tick());
+        verify(actionManager).forceSegmentReset();
         verify(actionManager).executeCommand(cmdStop);
         org.mockito.Mockito.verifyNoMoreInteractions(actionManager);
         assertEquals(AutoPilot.Mode.WAITING, autopilot.mode());


### PR DESCRIPTION
This PR moves all action/mutation methods (ensureForkRoute, notifySegmentOccupied, forceSegmentReset) from AutoPilotContext/TrainAutoPilotContext to TrainActionManager, leaving AutoPilotContext as a clean, read-only interface.