### PR TITLE
fix: deactivate autopilot when user changes speed in auto mode

### DIFF
--- a/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Locomotive.java
@@ -289,6 +289,9 @@ public class Locomotive extends Linker implements Tractor {
         // Speed change in auto mode → switch to manual
         if (getTrain() != null && getTrain().isAutoMode()) {
             getTrain().setAutoMode(false);
+            if (getTrain().getAutopilot() != null) {
+                getTrain().getAutopilot().deactivate();
+            }
         }
         setTargetSpeed(this.targetSpeed + 1);
     }
@@ -297,6 +300,9 @@ public class Locomotive extends Linker implements Tractor {
         // Speed change in auto mode → switch to manual
         if (getTrain() != null && getTrain().isAutoMode()) {
             getTrain().setAutoMode(false);
+            if (getTrain().getAutopilot() != null) {
+                getTrain().getAutopilot().deactivate();
+            }
         }
         setTargetSpeed(this.targetSpeed - 1);
     }


### PR DESCRIPTION
Cuando el usuario cambiaba la velocidad (incSpeed/decSpeed) en modo AUTO, se ponía autoMode=false pero NO se llamaba a autopilot.deactivate(). El ap.mode() seguía en FOLLOWING, y TrainSafetyManager seguía cambiando forks vía ap.ensureForkRoute() aunque el tren ya estuviera en manual.