### PR TITLE
fix: allow creeping at speed 1 in shunting mode so trains can separate

### DIFF
--- a/src/main/java/letrain/vehicle/impl/rail/Train.java
+++ b/src/main/java/letrain/vehicle/impl/rail/Train.java
@@ -569,18 +569,18 @@ public class Train implements Trailer<RailTrack>, Renderable, Transportable, Tra
             return false;
         }
 
-        // Shunting safety: if we share segments with another train that is moving,
-        // we must stop to avoid collisions. This prevents the TOCTOU bug where a
-        // stopped co-owner accelerates after a shunting lock was granted.
+        // Shunting safety: if another co-owner is moving, slow to minimum speed
+        // (1) instead of stopping. This lets both trains creep apart after a collision
+        // instead of blocking each other indefinitely.
         if (model != null && isShuntingMode()) {
             letrain.segments.BlockManager bm = model.getBlockManager();
             for (letrain.segments.Segment s : bm.getOwnedSegments(this)) {
                 for (Train owner : bm.getOwners(s)) {
                     if (owner != this && owner.getSpeed() != 0) {
-                        if (directorLinker != null) {
-                            directorLinker.setTargetSpeed(0);
+                        if (directorLinker != null && directorLinker.getTargetSpeed() > 1) {
+                            directorLinker.setTargetSpeed(1);
                         }
-                        return false;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Issue: #168

## Problema

Tras una colision, cuando un jugador invierte la marcha de un tren para separarlo del otro, el sistema TOCTOU detecta que el otro co-propietario (el otro tren accidentado) tambien se esta moviendo y frena ambos a velocidad 0. Esto bloquea la separacion indefinidamente.

## Causa

El codigo en Train.advance() (lineas 575-587) ponia targetSpeed=0 y return false cuando cualquier co-propietario de un segmento compartido se movia. Esto hacia que dos trenes que intentaban separarse se bloquearan mutuamente.

## Fix

En lugar de parar completamente (speed 0), se reduce a velocidad minima (1). Esto permite que ambos trenes avancen lentamente en direcciones opuestas y se separen. El TrainMovementManager seguira detectando contactos a baja velocidad (shunting mode downgrades crashes to contacts).

## Tests

334 tests, 0 fallos.