### PR TITLE
Refactor: convert TrainCouplingManager to stateless service

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -1,28 +1,43 @@
-# Plan de Implementación — Simplificación de Trailer y Mejora de TrainCouplingManager
+# Plan de Implementación — TrainCouplingManager Stateless
 
-Este plan propone limpiar el diseño del acoplamiento y estructura del tren simplificando la jerarquía de interfaces redundantes y aclarando el contrato de acoplamiento.
+Este plan describe el refactor para hacer que `TrainCouplingManager` sea stateless (sin estado de instancia). El estado efímero del acoplamiento (selecciones de UI) pasará a residir en `Train` como campos transitorios, y el gestor de acoplamiento se convertirá en un servicio puro de lógica ferroviaria.
 
 ## Cambios Propuestos
 
-### 1. Eliminar la Interfaz Redundante `Trailer`
-La interfaz `Trailer` es un artefacto obsoleto que solo implementa la clase `Train`, y cuyos métodos de mutación (`pushFront`, `popFront`, etc.) no son consumidos fuera de `Train`.
-- **Acción**: Eliminar [Trailer.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/rail/Trailer.java).
-- **Modificación en Train**:
-  - Quitar `implements Trailer<RailTrack>` de [Train.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/rail/impl/Train.java).
-  - Mantener como métodos públicos estándar en `Train` los métodos realmente útiles (como `getLinkers()`, `isEmpty()`, `size()`, `getFront()`, `getBack()`, `getDirectorLinker()`, `setDirectorLinker()`, `getTractors()`).
-  - Eliminar métodos no utilizados e innecesarios de la interfaz `Trailer` (tales como `joinTrailerBack`, `joinTrailerFront`, `pushFront`, `popFront`, `pushBack`, `popBack` que no tienen llamadas externas).
+### 1. Modificar la Entidad `Train`
+Añadir el estado transitorio del menú de acoplamiento a [Train.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/rail/impl/Train.java) y sus correspondientes getters y setters:
+- Campos transitorios:
+  - `private transient Deque<Linker> linkersToJoin = new LinkedList<>();`
+  - `private transient int numLinkersToJoin = 0;`
+  - `private transient Deque<Linker> linkersToRemove = new LinkedList<>();`
+  - `private transient int numLinkersToRemove = 0;`
+  - `private transient LinkersSense linkerJoinSense;`
+  - `private transient LinkersSense linkerDivisionSense;`
+  - `private transient boolean joined = false;`
+- Getters y setters para estos campos para mantener la compatibilidad con los Visitors y Presenters.
+- Mantener una referencia estática o compartida a la implementación stateless de `TrainCouplingManager` para llamadas locales rápidas si es necesario, o invocarla directamente.
 
-### 2. Aclarar y Documentar la Interfaz `TrainCouplingManager`
-El `TrainCouplingManager` maneja la lógica de acoplamiento y desacoplamiento, seleccionando y preparando qué vehículos (linkers) se unirán o separarán (impulsado por la UI o por lógica interna).
-- **Acción**: Documentar rigurosamente los métodos en [TrainCouplingManager.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/rail/TrainCouplingManager.java) con comentarios JavaDoc para clarificar su responsabilidad.
-- **Limpieza de getters/setters internos**: Mantener la interfaz limpia y comprensible.
+### 2. Refactorizar la Interfaz `TrainCouplingManager`
+Modificar [TrainCouplingManager.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/rail/TrainCouplingManager.java) para que todas las funciones acepten `Train train` como su primer argumento.
+
+### 3. Refactorizar la Implementación `TrainCouplingManager`
+Modificar [TrainCouplingManager.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/vehicle/rail/impl/TrainCouplingManager.java) para eliminar sus variables de instancia y adaptar todos sus métodos para que operen sobre el estado del objeto `Train` recibido como parámetro.
+
+### 4. Actualizar Presentadores e Invocadores
+Actualizar todas las llamadas en:
+- [TerminalPresenter.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/mvp/impl/terminal/TerminalPresenter.java)
+- [Gdx3DInputHandler.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/mvp/impl/graphic/Gdx3DInputHandler.java)
+- [Gdx3DHud.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/mvp/impl/graphic/Gdx3DHud.java)
+- [VehicleRenderer.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/visitor/gdx3d/VehicleRenderer.java)
+- [InfoVisitor.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/visitor/terminal/InfoVisitor.java)
+- [RenderVisitor.java](file:///home/antonio/dev/LeTrain/src/main/java/letrain/visitor/terminal/RenderVisitor.java)
 
 ---
 
 ## Plan de Verificación
 
 ### Pruebas Automatizadas
-- Compilar el proyecto y ejecutar los tests existentes para asegurar que no hay regresiones:
+- Compilar el proyecto y ejecutar la suite completa de pruebas:
   ```bash
   mvn clean test
   ```

--- a/src/main/java/letrain/command/CommandManager.java
+++ b/src/main/java/letrain/command/CommandManager.java
@@ -409,18 +409,16 @@ public class CommandManager extends LeTrainProgramBaseVisitor<Object> {
             boolean forward = "forward".equals(lCtx.sense().getText());
             int count = lCtx.NUMBER() != null ? Integer.parseInt(lCtx.NUMBER().getText()) : 0;
             return (t) -> {
-                t.trainCouplingManager.prepareLink(forward, count);
-                t.trainCouplingManager.joinLinkers();
+                t.trainCouplingManager.prepareLink(t, forward, count);
+                t.trainCouplingManager.joinLinkers(t);
             };
         } else if (ctx.unlinkAction() != null) {
             LeTrainProgramParser.UnlinkActionContext uCtx = ctx.unlinkAction();
             boolean forward = "forward".equals(uCtx.sense().getText());
             int count = uCtx.NUMBER() != null ? Integer.parseInt(uCtx.NUMBER().getText()) : 1;
             return (t) -> {
-
-                t.trainCouplingManager.prepareUnlink(forward, count);
-
-                t.trainCouplingManager.divideTrain(() -> model.nextTrainId());
+                t.trainCouplingManager.prepareUnlink(t, forward, count);
+                t.trainCouplingManager.divideTrain(t, () -> model.nextTrainId());
             };
         } else if (actionText.contains("unload")) {
             return (t) -> {

--- a/src/main/java/letrain/mvp/impl/graphic/Gdx3DHud.java
+++ b/src/main/java/letrain/mvp/impl/graphic/Gdx3DHud.java
@@ -29,6 +29,7 @@ import letrain.mvp.Model;
 import letrain.mvp.Model.GameModeMenuOption;
 import letrain.utils.FontManager;
 import letrain.vehicle.rail.impl.Locomotive;
+import letrain.vehicle.rail.impl.Train;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -377,12 +378,14 @@ public class Gdx3DHud {
                         if (newMode == letrain.mvp.Model.GameMode.LINK) {
                             if (model.getSelectedLocomotive() != null
                                     && model.getSelectedLocomotive().getTrain() != null) {
-                                model.getSelectedLocomotive().getTrain().trainCouplingManager.resetLinkState();
+                                Train train = model.getSelectedLocomotive().getTrain();
+                                train.trainCouplingManager.resetLinkState(train);
                             }
                         } else if (newMode == letrain.mvp.Model.GameMode.UNLINK) {
                             if (model.getSelectedLocomotive() != null
                                     && model.getSelectedLocomotive().getTrain() != null) {
-                                model.getSelectedLocomotive().getTrain().trainCouplingManager.resetUnlinkState();
+                                Train train = model.getSelectedLocomotive().getTrain();
+                                train.trainCouplingManager.resetUnlinkState(train);
                             }
                         }
                     }

--- a/src/main/java/letrain/mvp/impl/graphic/Gdx3DInputHandler.java
+++ b/src/main/java/letrain/mvp/impl/graphic/Gdx3DInputHandler.java
@@ -279,7 +279,8 @@ public class Gdx3DInputHandler implements InputProcessor {
                             model.setMode(Model.GameMode.LINK);
                             if (model.getSelectedLocomotive() != null
                                     && model.getSelectedLocomotive().getTrain() != null) {
-                                model.getSelectedLocomotive().getTrain().trainCouplingManager.resetLinkState();
+                                Train train = model.getSelectedLocomotive().getTrain();
+                                train.trainCouplingManager.resetLinkState(train);
                             }
                         }
                         return;
@@ -288,7 +289,8 @@ public class Gdx3DInputHandler implements InputProcessor {
                             model.setMode(Model.GameMode.UNLINK);
                             if (model.getSelectedLocomotive() != null
                                     && model.getSelectedLocomotive().getTrain() != null) {
-                                model.getSelectedLocomotive().getTrain().trainCouplingManager.resetUnlinkState();
+                                Train train = model.getSelectedLocomotive().getTrain();
+                                train.trainCouplingManager.resetUnlinkState(train);
                             }
                         }
                         return;
@@ -480,26 +482,26 @@ public class Gdx3DInputHandler implements InputProcessor {
             if (model.getSelectedLocomotive() != null && model.getSelectedLocomotive().getTrain() != null) {
                 Train train = model.getSelectedLocomotive().getTrain();
 
-                train.trainCouplingManager.updateLinkersToJoin(true);
+                train.trainCouplingManager.updateLinkersToJoin(train, true);
             }
         } else if (stroke.getKeyType() == KeyType.ArrowDown) {
             if (model.getSelectedLocomotive() != null && model.getSelectedLocomotive().getTrain() != null) {
                 Train train = model.getSelectedLocomotive().getTrain();
 
-                train.trainCouplingManager.updateLinkersToJoin(false);
+                train.trainCouplingManager.updateLinkersToJoin(train, false);
             }
         } else if (stroke.getKeyType() == KeyType.ArrowLeft) {
             if (model.getSelectedLocomotive() != null && model.getSelectedLocomotive().getTrain() != null) {
                 Train train = model.getSelectedLocomotive().getTrain();
-                if (train.trainCouplingManager.getNumLinkersToJoin() > 0) {
-                    train.trainCouplingManager.setNumLinkersToJoin(train.trainCouplingManager.getNumLinkersToJoin() - 1);
+                if (train.getNumLinkersToJoin() > 0) {
+                    train.setNumLinkersToJoin(train.getNumLinkersToJoin() - 1);
                 }
             }
         } else if (stroke.getKeyType() == KeyType.ArrowRight) {
             if (model.getSelectedLocomotive() != null && model.getSelectedLocomotive().getTrain() != null) {
                 Train train = model.getSelectedLocomotive().getTrain();
-                if (train.trainCouplingManager.getNumLinkersToJoin() < train.trainCouplingManager.getLinkersToJoin().size()) {
-                    train.trainCouplingManager.setNumLinkersToJoin(train.trainCouplingManager.getNumLinkersToJoin() + 1);
+                if (train.getNumLinkersToJoin() < train.getLinkersToJoin().size()) {
+                    train.setNumLinkersToJoin(train.getNumLinkersToJoin() + 1);
                 }
             }
         } else if (stroke.getKeyType() == KeyType.Character
@@ -507,8 +509,8 @@ public class Gdx3DInputHandler implements InputProcessor {
             Locomotive loco = model.getSelectedLocomotive();
             if (loco != null && loco.getTrain() != null) {
                 Train train = loco.getTrain();
-                if (!train.getLinkersToJoin().isEmpty() && train.trainCouplingManager.getNumLinkersToJoin() > 0) {
-                    train.trainCouplingManager.joinLinkers();
+                if (!train.getLinkersToJoin().isEmpty() && train.getNumLinkersToJoin() > 0) {
+                    train.trainCouplingManager.joinLinkers(train);
                 }
                 model.setMode(Model.GameMode.MENU);
             }
@@ -519,17 +521,17 @@ public class Gdx3DInputHandler implements InputProcessor {
         if (model.getSelectedLocomotive() != null && model.getSelectedLocomotive().getTrain() != null) {
             Train train = model.getSelectedLocomotive().getTrain();
             if (stroke.getKeyType() == KeyType.ArrowUp) {
-                train.trainCouplingManager.setFrontDivisionSense();
+                train.trainCouplingManager.setFrontDivisionSense(train);
             } else if (stroke.getKeyType() == KeyType.ArrowDown) {
-                train.trainCouplingManager.setBackDivisionSense();
+                train.trainCouplingManager.setBackDivisionSense(train);
             } else if (stroke.getKeyType() == KeyType.ArrowLeft) {
-                train.trainCouplingManager.selectPrevDivisionLink();
+                train.trainCouplingManager.selectPrevDivisionLink(train);
             } else if (stroke.getKeyType() == KeyType.ArrowRight) {
-                train.trainCouplingManager.selectNextDivisionLink();
+                train.trainCouplingManager.selectNextDivisionLink(train);
             } else if (stroke.getKeyType() == KeyType.Character
                     && stroke.getCharacter() == ' ') {
 
-                train.trainCouplingManager.divideTrain(() -> model.nextTrainId());
+                train.trainCouplingManager.divideTrain(train, () -> model.nextTrainId());
                 audioController.playOneShot("link",
                         (float) model.getSelectedLocomotive().getPosition().getX(),
                         (float) model.getSelectedLocomotive().getPosition().getY());

--- a/src/main/java/letrain/mvp/impl/terminal/TerminalPresenter.java
+++ b/src/main/java/letrain/mvp/impl/terminal/TerminalPresenter.java
@@ -293,7 +293,8 @@ public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListe
                     model.setMode(LINK);
                     if (model.getSelectedLocomotive() != null
                             && model.getSelectedLocomotive().getTrain() != null) {
-                        model.getSelectedLocomotive().getTrain().trainCouplingManager.resetLinkState();
+                        Train train = model.getSelectedLocomotive().getTrain();
+                        train.trainCouplingManager.resetLinkState(train);
                     }
                     return true;
                 }
@@ -303,7 +304,8 @@ public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListe
                     model.setMode(UNLINK);
                     if (model.getSelectedLocomotive() != null
                             && model.getSelectedLocomotive().getTrain() != null) {
-                        model.getSelectedLocomotive().getTrain().trainCouplingManager.resetUnlinkState();
+                        Train train = model.getSelectedLocomotive().getTrain();
+                        train.trainCouplingManager.resetUnlinkState(train);
                     }
                     return true;
                 }
@@ -472,16 +474,16 @@ public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListe
             case ArrowLeft:
                 if (model.getSelectedLocomotive() != null && model.getSelectedLocomotive().getTrain() != null) {
                     Train train = model.getSelectedLocomotive().getTrain();
-                    if (train.trainCouplingManager.getNumLinkersToJoin() > 0) {
-                        train.trainCouplingManager.setNumLinkersToJoin(train.trainCouplingManager.getNumLinkersToJoin() - 1);
+                    if (train.getNumLinkersToJoin() > 0) {
+                        train.setNumLinkersToJoin(train.getNumLinkersToJoin() - 1);
                     }
                 }
                 break;
             case ArrowRight:
                 if (model.getSelectedLocomotive() != null && model.getSelectedLocomotive().getTrain() != null) {
                     Train train = model.getSelectedLocomotive().getTrain();
-                    if (train.trainCouplingManager.getNumLinkersToJoin() < train.trainCouplingManager.getLinkersToJoin().size()) {
-                        train.trainCouplingManager.setNumLinkersToJoin(train.trainCouplingManager.getNumLinkersToJoin() + 1);
+                    if (train.getNumLinkersToJoin() < train.getLinkersToJoin().size()) {
+                        train.setNumLinkersToJoin(train.getNumLinkersToJoin() + 1);
                     }
                 }
                 break;
@@ -727,7 +729,7 @@ public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListe
         if (model.getSelectedLocomotive() != null) {
             Train train = model.getSelectedLocomotive().getTrain();
 
-            List<Linker> linkersToDestroy = train.trainCouplingManager.destroyLinkers(() -> model.nextTrainId());
+            List<Linker> linkersToDestroy = train.trainCouplingManager.destroyLinkers(train, () -> model.nextTrainId());
             for (Linker linker : linkersToDestroy) {
                 if (linker instanceof Locomotive) {
                     model.removeLocomotive((Locomotive) linker);
@@ -752,8 +754,8 @@ public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListe
             Locomotive loco = model.getSelectedLocomotive();
             if (loco.getTrain() != null) {
                 Train train = loco.getTrain();
-                if (!train.getLinkersToJoin().isEmpty() && train.trainCouplingManager.getNumLinkersToJoin() > 0) {
-                    train.trainCouplingManager.joinLinkers();
+                if (!train.getLinkersToJoin().isEmpty() && train.getNumLinkersToJoin() > 0) {
+                    train.trainCouplingManager.joinLinkers(train);
                 }
                 model.setMode(letrain.mvp.Model.GameMode.MENU);
             }
@@ -765,7 +767,7 @@ public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListe
                 model.getSelectedLocomotive().getTrain() != null) {
             Train train = model.getSelectedLocomotive().getTrain();
 
-            train.trainCouplingManager.updateLinkersToJoin(false);
+            train.trainCouplingManager.updateLinkersToJoin(train, false);
         }
     }
 
@@ -774,7 +776,7 @@ public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListe
             if (model.getSelectedLocomotive().getTrain() != null) {
                 Train train = model.getSelectedLocomotive().getTrain();
 
-                train.trainCouplingManager.updateLinkersToJoin(true);
+                train.trainCouplingManager.updateLinkersToJoin(train, true);
             } else {
                 // handle error
             }
@@ -784,19 +786,23 @@ public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListe
     }
 
     private void selectFrontDivisionSense() {
-        model.getSelectedLocomotive().getTrain().trainCouplingManager.setFrontDivisionSense();
+        Train train = model.getSelectedLocomotive().getTrain();
+        train.trainCouplingManager.setFrontDivisionSense(train);
     }
 
     private void selectBackDivisionSense() {
-        model.getSelectedLocomotive().getTrain().trainCouplingManager.setBackDivisionSense();
+        Train train = model.getSelectedLocomotive().getTrain();
+        train.trainCouplingManager.setBackDivisionSense(train);
     }
 
     private void selectNextLink() {
-        model.getSelectedLocomotive().getTrain().trainCouplingManager.selectNextDivisionLink();
+        Train train = model.getSelectedLocomotive().getTrain();
+        train.trainCouplingManager.selectNextDivisionLink(train);
     }
 
     private void selectPrevLink() {
-        model.getSelectedLocomotive().getTrain().trainCouplingManager.selectPrevDivisionLink();
+        Train train = model.getSelectedLocomotive().getTrain();
+        train.trainCouplingManager.selectPrevDivisionLink(train);
     }
 
     private void divideTrain() {
@@ -804,7 +810,7 @@ public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListe
         if (loco != null && loco.getTrain() != null) {
             Train train = loco.getTrain();
 
-            train.trainCouplingManager.divideTrain(() -> model.nextTrainId());
+            train.trainCouplingManager.divideTrain(train, () -> model.nextTrainId());
             audioController.playOneShot("link",
                     (float) loco.getPosition().getX(),
                     (float) loco.getPosition().getY());

--- a/src/main/java/letrain/vehicle/rail/TrainCouplingManager.java
+++ b/src/main/java/letrain/vehicle/rail/TrainCouplingManager.java
@@ -7,68 +7,44 @@ import org.slf4j.LoggerFactory;
 import java.util.Deque;
 import java.util.List;
 import java.util.function.Supplier;
+import letrain.vehicle.rail.impl.Train;
 
+/**
+ * Service providing stateless operations for coupling and uncoupling trains.
+ * Transient state is stored directly in the Train instances.
+ */
 public interface TrainCouplingManager {
     Logger log = LoggerFactory.getLogger(letrain.vehicle.rail.impl.TrainCouplingManager.class);
 
-    int getNumLinkersToJoin();
+    List<Linker> getSelectedLinkersToJoin(Train train);
 
-    int getNumLinkersToRemove();
+    void updateLinkersToJoin(Train train, boolean forwardDirection);
 
+    void joinLinkers(Train train);
 
-    List<Linker> getSelectedLinkersToJoin()/*
-     * - Vaciamos los linkersToJoin
-     * - Si solicitan forwardDirection, lastLinker es getFirst(), si no es
-     * getLast(), es decir, que vamos agregar linkers en ese sentido seleccionado.
-     * - En dir ponemos la dirección de "salida" del tren, es decir, la que apuntará
-     * a despegarse del tren. Pero ahí necesitamos saber si el tren está invertido o
-     * no.
-     * - Si el tren no está invertido, la dirección de salida del primer linker es
-     * la correcta, pero la del último será la inversa de su track.
-     * - Si el tren está invertido es lo contrario, la que hay que invertir es la
-     * primera.
-     */;
+    void prepareLink(Train train, boolean forward, int count);
 
+    void prepareUnlink(Train train, boolean forward, int count);
 
-    void updateLinkersToJoin(boolean forwardDirection);
+    void setFrontDivisionSense(Train train);
 
-    void joinLinkers();
+    void setBackDivisionSense(Train train);
 
-    void prepareLink(boolean forward, int count);
+    void resetUnlinkState(Train train);
 
-    void prepareUnlink(boolean forward, int count);
+    void resetLinkState(Train train);
 
-    void setFrontDivisionSense();
+    void selectNextDivisionLink(Train train);
 
-    void setBackDivisionSense();
+    void selectPrevDivisionLink(Train train);
 
-    void resetUnlinkState();
+    void updateLinkersToRemove(Train train);
 
-    void resetLinkState();
+    void divideTrain(Train train, Supplier<Integer> nextTrainIdSupplier);
 
-    void selectNextDivisionLink();
+    List<Linker> destroyLinkers(Train train, Supplier<Integer> nextTrainIdSupplier);
 
-    void selectPrevDivisionLink();
-
-    void updateLinkersToRemove();
-
-    void divideTrain(Supplier<Integer> nextTrainIdSupplier);
-
-    List<Linker> destroyLinkers(Supplier<Integer> nextTrainIdSupplier);
-
-    Dir getLinkDir(Linker linker);
+    Dir getLinkDir(Train train, Linker linker);
 
     Linker getAdjacentLinker(Linker linker, Dir dir);
-
-    void setNumLinkersToRemove(int numLinkersToRemove);
-
-    void setNumLinkersToJoin(int numLinkersToJoin);
-
-    Deque<Linker> getLinkersToJoin();
-
-    void setLinkersToJoin(Deque<Linker> linkersToJoin);
-
-    Deque<Linker> getLinkersToRemove();
-
-    void setLinkersToRemove(Deque<Linker> linkersToRemove);
 }

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -68,6 +68,15 @@ public class Train implements Renderable {
     private transient boolean isNotifying = false;
     public transient boolean pendingReverse = false;
 
+    // Transient coupling menu selection state
+    private transient Deque<Linker> linkersToJoin = new LinkedList<>();
+    private transient int numLinkersToJoin = 0;
+    private transient Deque<Linker> linkersToRemove = new LinkedList<>();
+    private transient int numLinkersToRemove = 0;
+    public transient LinkersSense linkerJoinSense;
+    public transient LinkersSense linkerDivisionSense;
+    public transient boolean joined = false;
+
 
 
     public Train(int id) {
@@ -76,7 +85,7 @@ public class Train implements Renderable {
         this.scriptTrainListeners = new CopyOnWriteArrayList<>();
         this.coreTrainListeners = new CopyOnWriteArrayList<>();
 
-        this.trainCouplingManager = new letrain.vehicle.rail.impl.TrainCouplingManager(this);
+        this.trainCouplingManager = new letrain.vehicle.rail.impl.TrainCouplingManager();
         this.setLogisticsManager(new TrainLogisticsManager(this));
         this.movementManager = new letrain.vehicle.rail.impl.TrainMovementManager(this);
         this.safetyManager = new letrain.vehicle.rail.impl.TrainSafetyManager(this);
@@ -359,7 +368,7 @@ public class Train implements Renderable {
         this.scriptTrainListeners = SerializationHelper.ensureListInitializedConcurrent(scriptTrainListeners);
         this.coreTrainListeners = SerializationHelper.ensureListInitializedConcurrent(coreTrainListeners);
         this.isNotifying = false;
-        this.trainCouplingManager = new letrain.vehicle.rail.impl.TrainCouplingManager(this);
+        this.trainCouplingManager = new letrain.vehicle.rail.impl.TrainCouplingManager();
         this.safetyManager = new letrain.vehicle.rail.impl.TrainSafetyManager(this);
         this.movementManager = new letrain.vehicle.rail.impl.TrainMovementManager(this);
         if (this.autopilot != null) {
@@ -387,7 +396,59 @@ public class Train implements Renderable {
     }
 
     public Deque<Linker> getLinkersToJoin() {
-        return this.trainCouplingManager.getLinkersToJoin();
+        return linkersToJoin;
+    }
+
+    public void setLinkersToJoin(Deque<Linker> linkersToJoin) {
+        this.linkersToJoin = linkersToJoin;
+    }
+
+    public Deque<Linker> getLinkersToRemove() {
+        return linkersToRemove;
+    }
+
+    public void setLinkersToRemove(Deque<Linker> linkersToRemove) {
+        this.linkersToRemove = linkersToRemove;
+    }
+
+    public int getNumLinkersToJoin() {
+        return numLinkersToJoin;
+    }
+
+    public void setNumLinkersToJoin(int numLinkersToJoin) {
+        this.numLinkersToJoin = numLinkersToJoin;
+    }
+
+    public int getNumLinkersToRemove() {
+        return numLinkersToRemove;
+    }
+
+    public void setNumLinkersToRemove(int numLinkersToRemove) {
+        this.numLinkersToRemove = numLinkersToRemove;
+    }
+
+    public LinkersSense getLinkerJoinSense() {
+        return linkerJoinSense;
+    }
+
+    public void setLinkerJoinSense(LinkersSense linkerJoinSense) {
+        this.linkerJoinSense = linkerJoinSense;
+    }
+
+    public LinkersSense getLinkerDivisionSense() {
+        return linkerDivisionSense;
+    }
+
+    public void setLinkerDivisionSense(LinkersSense linkerDivisionSense) {
+        this.linkerDivisionSense = linkerDivisionSense;
+    }
+
+    public boolean isJoined() {
+        return joined;
+    }
+
+    public void setJoined(boolean joined) {
+        this.joined = joined;
     }
 
     public void pushFront(Linker linker) {

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -1,7 +1,6 @@
 package letrain.vehicle.rail.impl;
 
 import letrain.mvp.Model;
-import letrain.track.rail.RailTrack;
 import letrain.utils.SerializationHelper;
 import letrain.utils.ValidationUtils;
 import letrain.vehicle.Tractor;
@@ -32,14 +31,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class Train implements Renderable {
     static final int CRASH_SPEED_THRESHOLD = 5;
     public static final Logger log = LoggerFactory.getLogger(Train.class);
-
-    public letrain.vehicle.rail.TrainLogisticsManager getLogisticsManager() {
-        return logisticsManager;
-    }
-
-    public void setLogisticsManager(letrain.vehicle.rail.TrainLogisticsManager logisticsManager) {
-        this.logisticsManager = logisticsManager;
-    }
 
     enum LinkersSense {
         FRONT, BACK
@@ -77,8 +68,6 @@ public class Train implements Renderable {
     public transient LinkersSense linkerDivisionSense;
     public transient boolean joined = false;
 
-
-
     public Train(int id) {
         this.id = ValidationUtils.requirePositive(id, "train id");
         this.linkers = new LinkedList<>();
@@ -97,6 +86,13 @@ public class Train implements Renderable {
      */
     protected Train() {
         this(1);
+    }
+    public letrain.vehicle.rail.TrainLogisticsManager getLogisticsManager() {
+        return logisticsManager;
+    }
+
+    public void setLogisticsManager(letrain.vehicle.rail.TrainLogisticsManager logisticsManager) {
+        this.logisticsManager = logisticsManager;
     }
 
     public letrain.vehicle.rail.TrainSafetyManager getSafetyManager() {
@@ -492,10 +488,7 @@ public class Train implements Renderable {
     }
 
     public Linker getPhysicalFront() {
-        boolean normalSense = true;
-        if (getDirectorLinker() != null && getDirectorLinker().isReversed()) {
-            normalSense = false;
-        }
+        boolean normalSense = getDirectorLinker() == null || !getDirectorLinker().isReversed();
         return normalSense ? getFront() : getBack();
     }
 

--- a/src/main/java/letrain/vehicle/rail/impl/TrainCouplingManager.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainCouplingManager.java
@@ -9,9 +9,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import letrain.map.Dir;
 import letrain.track.Track;
 import letrain.vehicle.rail.Linker;
@@ -19,65 +16,27 @@ import letrain.vehicle.rail.RailIterator;
 import letrain.vehicle.rail.TrainEventListener;
 
 public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingManager {
-    private final Train train;
-    @JsonProperty("linkersToJoin")
-    @JsonDeserialize(as = LinkedList.class)
-    private Deque<Linker> linkersToJoin;
-    private int numLinkersToRemove = 0;
-    private int numLinkersToJoin = 0;
-    @JsonProperty("linkersToRemove")
-    @JsonDeserialize(as = LinkedList.class)
-    private Deque<Linker> linkersToRemove;
-    Train.LinkersSense linkerJoinSense;
-    Train.LinkersSense linkerDivisionSense;
-    boolean joined = false;
 
-    public TrainCouplingManager(Train train) {
-        this.train = train;
-        this.setLinkersToJoin(new LinkedList<>());
-        this.setLinkersToRemove(new LinkedList<>());
-
+    public TrainCouplingManager() {
+        // Stateless service constructor
     }
 
     @Override
-    public int getNumLinkersToJoin() {
-        return numLinkersToJoin;
-    }
-
-    @Override
-    public int getNumLinkersToRemove() {
-        return numLinkersToRemove;
-    }
-
-    @JsonIgnore
-    @Override
-    public List<Linker> getSelectedLinkersToJoin() {
-        if (getLinkersToJoin().isEmpty() || getNumLinkersToJoin() == 0)
+    public List<Linker> getSelectedLinkersToJoin(Train train) {
+        if (train.getLinkersToJoin().isEmpty() || train.getNumLinkersToJoin() == 0)
             return new ArrayList<Linker>();
         // Convert deque to list to slice it
-        List<Linker> all = new ArrayList<Linker>(getLinkersToJoin());
+        List<Linker> all = new ArrayList<Linker>(train.getLinkersToJoin());
         // Logic might differ based on iteration order of deque vs join sense
         // linkersToJoin is populated in order of distance from train.
         // so we just take the first N.
-        return all.subList(0, getNumLinkersToJoin());
-    }/*
-     * - Vaciamos los linkersToJoin
-     * - Si solicitan forwardDirection, lastLinker es getFirst(), si no es
-     * getLast(), es decir, que vamos agregar linkers en ese sentido seleccionado.
-     * - En dir ponemos la dirección de "salida" del tren, es decir, la que apuntará
-     * a despegarse del tren. Pero ahí necesitamos saber si el tren está invertido o
-     * no.
-     * - Si el tren no está invertido, la dirección de salida del primer linker es
-     * la correcta, pero la del último será la inversa de su track.
-     * - Si el tren está invertido es lo contrario, la que hay que invertir es la
-     * primera.
-     */
+        return all.subList(0, train.getNumLinkersToJoin());
+    }
 
-    @JsonIgnore
     @Override
-    public void updateLinkersToJoin(boolean forwardDirection) {
-        getLinkersToJoin().clear();
-        joined = false;
+    public void updateLinkersToJoin(Train train, boolean forwardDirection) {
+        train.getLinkersToJoin().clear();
+        train.setJoined(false);
         Linker lastLinker = null;
         Dir dir = Dir.E;
 
@@ -88,20 +47,20 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
                 entryDir = lastLinker.getRealDir().inverse();
             }
             if (forwardDirection) {
-                linkerJoinSense = Train.LinkersSense.FRONT;
+                train.setLinkerJoinSense(Train.LinkersSense.FRONT);
                 dir = lastLinker.getTrack().getDir(entryDir);
             } else {
-                linkerJoinSense = Train.LinkersSense.BACK;
+                train.setLinkerJoinSense(Train.LinkersSense.BACK);
                 dir = entryDir;
             }
         } else if (train.getLinkers().size() > 1) {
             if (forwardDirection) {
                 lastLinker = train.getLinkers().getFirst();
-                linkerJoinSense = Train.LinkersSense.FRONT;
-                dir = getLinkDir(lastLinker);
+                train.setLinkerJoinSense(Train.LinkersSense.FRONT);
+                dir = getLinkDir(train, lastLinker);
             } else {
                 lastLinker = train.getLinkers().getLast();
-                linkerJoinSense = Train.LinkersSense.BACK;
+                train.setLinkerJoinSense(Train.LinkersSense.BACK);
                 // Find the connection from the last linker that leads away
                 // from our own train (empty track or different train).
                 Track lastTrack = lastLinker.getTrack();
@@ -145,7 +104,7 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
                 if (nextLinker != null && train != nextLinker.getTrain()) {
                     while (nextLinker != null) {
                         if (nextLinker.getTrain() != train) {
-                            getLinkersToJoin().add(nextLinker);
+                            train.getLinkersToJoin().add(nextLinker);
                         }
                         if (!iterator.advance()) {
                             break;
@@ -155,20 +114,20 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
                 }
             }
         }
-        setNumLinkersToJoin(getLinkersToJoin().size());
+        train.setNumLinkersToJoin(train.getLinkersToJoin().size());
     }
 
     @Override
-    public void joinLinkers() {
-        if (!joined) {
+    public void joinLinkers(Train train) {
+        if (!train.isJoined()) {
             int count = 0;
             boolean linkersActuallyAdded = false;
             Set<Train> affectedOldTrains = new HashSet<Train>();
-            for (Linker linkerToJoin : getLinkersToJoin()) {
-                if (count >= getNumLinkersToJoin())
+            for (Linker linkerToJoin : train.getLinkersToJoin()) {
+                if (count >= train.getNumLinkersToJoin())
                     break;
 
-                if (linkerJoinSense == Train.LinkersSense.FRONT) {
+                if (train.getLinkerJoinSense() == Train.LinkersSense.FRONT) {
                     train.getLinkers().addFirst(linkerToJoin);
                 } else {
                     train.getLinkers().addLast(linkerToJoin);
@@ -199,8 +158,8 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
                 }
             }
 
-            getLinkersToJoin().clear();
-            joined = true;
+            train.getLinkersToJoin().clear();
+            train.setJoined(true);
             if (linkersActuallyAdded) {
                 train.movementManager.refreshLinkersDirection();
                 train.setStalled(false);
@@ -210,134 +169,134 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
     }
 
     @Override
-    public void prepareLink(boolean forward, int count) {
-        updateLinkersToJoin(forward);
-        if (count > 0 && count < getLinkersToJoin().size()) {
-            setNumLinkersToJoin(count);
+    public void prepareLink(Train train, boolean forward, int count) {
+        updateLinkersToJoin(train, forward);
+        if (count > 0 && count < train.getLinkersToJoin().size()) {
+            train.setNumLinkersToJoin(count);
         } else {
-            setNumLinkersToJoin(getLinkersToJoin().size());
+            train.setNumLinkersToJoin(train.getLinkersToJoin().size());
         }
     }
 
     @Override
-    public void prepareUnlink(boolean forward, int count) {
+    public void prepareUnlink(Train train, boolean forward, int count) {
         if (train.getDirectorLinker() != null && train.getDirectorLinker().getSpeed() > 0) {
             return;
         }
 
         if (forward) {
-            linkerDivisionSense = Train.LinkersSense.FRONT;
+            train.setLinkerDivisionSense(Train.LinkersSense.FRONT);
         } else {
-            linkerDivisionSense = Train.LinkersSense.BACK;
+            train.setLinkerDivisionSense(Train.LinkersSense.BACK);
         }
 
         int maxRemovable = Math.max(0, train.getLinkers().size() - 1);
         if (maxRemovable == 0) {
-            setNumLinkersToRemove(0);
+            train.setNumLinkersToRemove(0);
         } else if (count <= 0) {
-            setNumLinkersToRemove(1);
+            train.setNumLinkersToRemove(1);
         } else {
-            setNumLinkersToRemove(Math.min(Math.max(1, count), maxRemovable));
+            train.setNumLinkersToRemove(Math.min(Math.max(1, count), maxRemovable));
         }
 
-        updateLinkersToRemove();
+        updateLinkersToRemove(train);
     }
 
     @Override
-    public void setFrontDivisionSense() {
+    public void setFrontDivisionSense(Train train) {
         if (train.getDirectorLinker() != null && train.getDirectorLinker().getSpeed() > 0) {
             return;
         }
-        linkerDivisionSense = Train.LinkersSense.FRONT;
-        setNumLinkersToRemove(train.calcInitialUnlinkCount());
-        updateLinkersToRemove();
+        train.setLinkerDivisionSense(Train.LinkersSense.FRONT);
+        train.setNumLinkersToRemove(train.calcInitialUnlinkCount());
+        updateLinkersToRemove(train);
     }
 
     @Override
-    public void setBackDivisionSense() {
+    public void setBackDivisionSense(Train train) {
         if (train.getDirectorLinker() != null && train.getDirectorLinker().getSpeed() > 0) {
             return;
         }
-        linkerDivisionSense = Train.LinkersSense.BACK;
-        setNumLinkersToRemove(train.calcInitialUnlinkCount());
-        updateLinkersToRemove();
+        train.setLinkerDivisionSense(Train.LinkersSense.BACK);
+        train.setNumLinkersToRemove(train.calcInitialUnlinkCount());
+        updateLinkersToRemove(train);
     }
 
     @Override
-    public void resetUnlinkState() {
+    public void resetUnlinkState(Train train) {
         if (!train.getLinkers().isEmpty() && train.getLinkers().peekLast() == train.getDirectorLinker()) {
-            linkerDivisionSense = Train.LinkersSense.FRONT;
+            train.setLinkerDivisionSense(Train.LinkersSense.FRONT);
         } else {
-            linkerDivisionSense = Train.LinkersSense.BACK;
+            train.setLinkerDivisionSense(Train.LinkersSense.BACK);
         }
-        setNumLinkersToRemove(train.calcInitialUnlinkCount());
-        updateLinkersToRemove();
+        train.setNumLinkersToRemove(train.calcInitialUnlinkCount());
+        updateLinkersToRemove(train);
     }
 
     @Override
-    public void resetLinkState() {
-        setNumLinkersToJoin(0);
-        getLinkersToJoin().clear();
+    public void resetLinkState(Train train) {
+        train.setNumLinkersToJoin(0);
+        train.getLinkersToJoin().clear();
     }
 
     @Override
-    public void selectNextDivisionLink() {
+    public void selectNextDivisionLink(Train train) {
         if (train.getDirectorLinker() != null && train.getDirectorLinker().getSpeed() > 0) {
             return;
         }
-        if (getNumLinkersToRemove() < train.getLinkers().size() - 1) {
-            setNumLinkersToRemove(getNumLinkersToRemove() + 1);
+        if (train.getNumLinkersToRemove() < train.getLinkers().size() - 1) {
+            train.setNumLinkersToRemove(train.getNumLinkersToRemove() + 1);
         }
-        updateLinkersToRemove();
+        updateLinkersToRemove(train);
     }
 
     @Override
-    public void selectPrevDivisionLink() {
+    public void selectPrevDivisionLink(Train train) {
         if (train.getDirectorLinker() != null && train.getDirectorLinker().getSpeed() > 0) {
             return;
         }
-        if (getNumLinkersToRemove() > 0) {
-            setNumLinkersToRemove(getNumLinkersToRemove() - 1);
+        if (train.getNumLinkersToRemove() > 0) {
+            train.setNumLinkersToRemove(train.getNumLinkersToRemove() - 1);
         }
-        updateLinkersToRemove();
+        updateLinkersToRemove(train);
     }
 
     @Override
-    public void updateLinkersToRemove() {
-        getLinkersToRemove().clear();
+    public void updateLinkersToRemove(Train train) {
+        train.getLinkersToRemove().clear();
         Iterator<Linker> linkerIterator = train.getLinkers().iterator();
-        if (linkerDivisionSense == Train.LinkersSense.FRONT) {
+        if (train.getLinkerDivisionSense() == Train.LinkersSense.FRONT) {
             linkerIterator = train.getLinkers().iterator();
         } else {
             linkerIterator = train.getLinkers().descendingIterator();
         }
-        for (int n = 0; n < getNumLinkersToRemove(); n++) {
+        for (int n = 0; n < train.getNumLinkersToRemove(); n++) {
             if (linkerIterator.hasNext()) {
                 Linker next = linkerIterator.next();
                 if (next != train.getDirectorLinker()) {
-                    getLinkersToRemove().addLast(next);
+                    train.getLinkersToRemove().addLast(next);
                 } else {
                     // Si nos topamos con el director, no podemos desvincularlo, así que ajustamos
                     // la cuenta al número actual de elementos válidos y paramos.
-                    setNumLinkersToRemove(n);
+                    train.setNumLinkersToRemove(n);
                     return;
                 }
             } else {
                 // Si no hay más elementos en el iterador, ajustamos la cuenta al número real
                 // encontrado.
-                setNumLinkersToRemove(n);
+                train.setNumLinkersToRemove(n);
                 break;
             }
         }
     }
 
     @Override
-    public void divideTrain(Supplier<Integer> nextTrainIdSupplier) {
+    public void divideTrain(Train train, Supplier<Integer> nextTrainIdSupplier) {
         if (train.getDirectorLinker() != null && train.getDirectorLinker().getSpeed() > 0) {
             return;
         }
 
-        int toRemove = getLinkersToRemove().size();
+        int toRemove = train.getLinkersToRemove().size();
         if (toRemove > 0) {
             Train newTrain = new Train(nextTrainIdSupplier.get());
             newTrain.setModel(train.getModel());
@@ -350,7 +309,7 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
 
             for (int n = 0; n < toRemove; n++) {
                 Linker linkerToRemove;
-                if (linkerDivisionSense == Train.LinkersSense.BACK) {
+                if (train.getLinkerDivisionSense() == Train.LinkersSense.BACK) {
                     linkerToRemove = train.getLinkers().removeLast();
                     newTrain.getLinkers().addFirst(linkerToRemove);
                 } else {
@@ -366,21 +325,21 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
 
         train.assignDefaultDirectorLinker();
         train.rebind();
-        getLinkersToRemove().clear();
-        setNumLinkersToRemove(0);
+        train.getLinkersToRemove().clear();
+        train.setNumLinkersToRemove(0);
         train.movementManager.refreshLinkersDirection();
         train.setStalled(false);
         train.notifyUnlink();
     }
 
     @Override
-    public List<Linker> destroyLinkers(Supplier<Integer> nextTrainIdSupplier) {
+    public List<Linker> destroyLinkers(Train train, Supplier<Integer> nextTrainIdSupplier) {
         if (train.getDirectorLinker() != null && train.getDirectorLinker().getSpeed() > 0) {
             return new ArrayList<Linker>();
         }
 
         List<Linker> linkersToDestroy = new ArrayList<Linker>();
-        if (getNumLinkersToRemove() > 0) {
+        if (train.getNumLinkersToRemove() > 0) {
             Train newTrain = new Train(nextTrainIdSupplier.get());
             newTrain.setModel(train.getModel());
             for (TrainEventListener listener : train.getScriptTrainListeners()) {
@@ -390,9 +349,9 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
                 newTrain.addCoreTrainEventListener(listener);
             }
 
-            for (int n = 0; n < getNumLinkersToRemove(); n++) {
+            for (int n = 0; n < train.getNumLinkersToRemove(); n++) {
                 Linker linkerToRemove;
-                if (linkerDivisionSense == Train.LinkersSense.BACK) {
+                if (train.getLinkerDivisionSense() == Train.LinkersSense.BACK) {
                     linkerToRemove = train.getLinkers().removeLast();
                     newTrain.getLinkers().addFirst(linkerToRemove);
                 } else {
@@ -408,13 +367,13 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
 
         train.assignDefaultDirectorLinker();
         train.rebind();
-        getLinkersToRemove().clear();
-        setNumLinkersToRemove(0);
+        train.getLinkersToRemove().clear();
+        train.setNumLinkersToRemove(0);
         return linkersToDestroy;
     }
 
     @Override
-    public Dir getLinkDir(Linker linker) {
+    public Dir getLinkDir(Train train, Linker linker) {
         Dir linkerDir = linker.getDir();
         Linker adjacentLinker = getAdjacentLinker(linker, linkerDir);
         if (adjacentLinker != null && adjacentLinker.getTrain() != train) {
@@ -468,35 +427,5 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
             return linker.getTrack().getConnected(dir).getLinker();
         }
         return null;
-    }
-
-    @Override
-    public void setNumLinkersToRemove(int numLinkersToRemove) {
-        this.numLinkersToRemove = numLinkersToRemove;
-    }
-
-    @Override
-    public void setNumLinkersToJoin(int numLinkersToJoin) {
-        this.numLinkersToJoin = numLinkersToJoin;
-    }
-
-    @Override
-    public Deque<Linker> getLinkersToJoin() {
-        return linkersToJoin;
-    }
-
-    @Override
-    public void setLinkersToJoin(Deque<Linker> linkersToJoin) {
-        this.linkersToJoin = linkersToJoin;
-    }
-
-    @Override
-    public Deque<Linker> getLinkersToRemove() {
-        return linkersToRemove;
-    }
-
-    @Override
-    public void setLinkersToRemove(Deque<Linker> linkersToRemove) {
-        this.linkersToRemove = linkersToRemove;
     }
 }

--- a/src/main/java/letrain/visitor/gdx3d/VehicleRenderer.java
+++ b/src/main/java/letrain/visitor/gdx3d/VehicleRenderer.java
@@ -37,7 +37,8 @@ public class VehicleRenderer extends BaseSubRenderer {
                     // Logic might differ based on iteration order of deque vs join sense
                     // linkersToJoin is populated in order of distance from train.
                     // so we just take the first N.
-                    for (Linker l : selected.getTrain().trainCouplingManager.getSelectedLinkersToJoin()) {
+                    Train train = selected.getTrain();
+                    for (Linker l : train.trainCouplingManager.getSelectedLinkersToJoin(train)) {
                         if (l == locomotive) {
                             highlight = true;
                             break;
@@ -47,7 +48,8 @@ public class VehicleRenderer extends BaseSubRenderer {
             } else if (modelRef.getMode() == letrain.mvp.Model.GameMode.UNLINK) {
                 Locomotive selected = modelRef.getSelectedLocomotive();
                 if (selected != null && selected.getTrain() != null) {
-                    for (Linker l : selected.getTrain().trainCouplingManager.getLinkersToRemove()) {
+                    Train train = selected.getTrain();
+                    for (Linker l : train.getLinkersToRemove()) {
                         if (l == locomotive) {
                             unlinkHighlight = true;
                             break;
@@ -196,7 +198,8 @@ public class VehicleRenderer extends BaseSubRenderer {
                     // Logic might differ based on iteration order of deque vs join sense
                     // linkersToJoin is populated in order of distance from train.
                     // so we just take the first N.
-                    for (Linker l : selected.getTrain().trainCouplingManager.getSelectedLinkersToJoin()) {
+                    Train train = selected.getTrain();
+                    for (Linker l : train.trainCouplingManager.getSelectedLinkersToJoin(train)) {
                         if (l == wagon) {
                             highlight = true;
                             break;
@@ -206,7 +209,8 @@ public class VehicleRenderer extends BaseSubRenderer {
             } else if (modelRef.getMode() == letrain.mvp.Model.GameMode.UNLINK) {
                 Locomotive selected = modelRef.getSelectedLocomotive();
                 if (selected != null && selected.getTrain() != null) {
-                    for (Linker l : selected.getTrain().trainCouplingManager.getLinkersToRemove()) {
+                    Train train = selected.getTrain();
+                    for (Linker l : train.getLinkersToRemove()) {
                         if (l == wagon) {
                             unlinkHighlight = true;
                             break;

--- a/src/main/java/letrain/visitor/terminal/InfoVisitor.java
+++ b/src/main/java/letrain/visitor/terminal/InfoVisitor.java
@@ -23,6 +23,7 @@ import letrain.track.rail.TunnelGateRailTrack;
 import letrain.track.rail.TunnelRailTrack;
 import letrain.vehicle.Cursor;
 import letrain.vehicle.rail.impl.Locomotive;
+import letrain.vehicle.rail.impl.Train;
 import letrain.vehicle.rail.impl.Wagon;
 import letrain.visitor.Visitor;
 
@@ -78,8 +79,9 @@ public class InfoVisitor implements Visitor {
                     // Logic might differ based on iteration order of deque vs join sense
                     // linkersToJoin is populated in order of distance from train.
                     // so we just take the first N.
-                    infoBarText += " Vagones: " + selected.getTrain().trainCouplingManager.getSelectedLinkersToJoin().size() + "/"
-                            + selected.getTrain().getLinkersToJoin().size();
+                    Train train = selected.getTrain();
+                    infoBarText += " Vagones: " + train.trainCouplingManager.getSelectedLinkersToJoin(train).size() + "/"
+                            + train.getLinkersToJoin().size();
                 }
                 break;
             case UNLINK:

--- a/src/main/java/letrain/visitor/terminal/RenderVisitor.java
+++ b/src/main/java/letrain/visitor/terminal/RenderVisitor.java
@@ -242,12 +242,12 @@ public class RenderVisitor implements Visitor {
         if (selectedLocomotive != null && selectedLocomotive.getTrain() != null) {
             Train activeTrain = selectedLocomotive.getTrain();
             boolean highlighted = false;
-            if (activeTrain.trainCouplingManager.getLinkersToRemove().contains(linker)) {
+            if (activeTrain.getLinkersToRemove().contains(linker)) {
                 highlighted = true;
             } else {
                 int count = 0;
                 for (Linker linkerToJoin : activeTrain.getLinkersToJoin()) {
-                    if (count >= activeTrain.trainCouplingManager.getNumLinkersToJoin())
+                    if (count >= activeTrain.getNumLinkersToJoin())
                         break;
                     if (linkerToJoin == linker) {
                         highlighted = true;

--- a/src/test/java/letrain/SerializationTest.java
+++ b/src/test/java/letrain/SerializationTest.java
@@ -321,9 +321,9 @@ class SerializationTest {
 
         // Unlink one vehicle from the front side (frontWagon), leaving loco+backWagon
         // intact
-        train.trainCouplingManager.setFrontDivisionSense();
+        train.trainCouplingManager.setFrontDivisionSense(train);
 
-        train.trainCouplingManager.divideTrain(() -> 501);
+        train.trainCouplingManager.divideTrain(train, () -> 501);
 
         assertEquals(2, train.getLinkers().size(), "Train should keep two linkers after unlinking one from front");
         assertTrue(train.getLinkers().contains(loco));

--- a/src/test/java/letrain/vehicle/rail/rail2/UnlinkBlockManagerTest.java
+++ b/src/test/java/letrain/vehicle/rail/rail2/UnlinkBlockManagerTest.java
@@ -79,12 +79,12 @@ class UnlinkBlockManagerTest {
 
         // Prepare Unlink (Back, 1 wagon)
 
-        train.trainCouplingManager.prepareUnlink(false, 1);
-        assertEquals(1, train.trainCouplingManager.getNumLinkersToRemove());
+        train.trainCouplingManager.prepareUnlink(train, false, 1);
+        assertEquals(1, train.getNumLinkersToRemove());
         
         // Divide Train
 
-        train.trainCouplingManager.divideTrain(() -> 2);
+        train.trainCouplingManager.divideTrain(train, () -> 2);
 
         // Verification:
         // 1. We should have two trains now.


### PR DESCRIPTION
This PR refactors the TrainCouplingManager to be a stateless service. The transient coupling menu state (like linkersToJoin, numLinkersToJoin, etc.) now resides directly on the Train class as transient fields. All coupling manager methods have been updated to receive Train as their first parameter.