### PR TITLE
refactor: always instantiate autopilot on Train and delegate autoMode state

### DIFF
--- a/src/main/java/letrain/command/CommandManager.java
+++ b/src/main/java/letrain/command/CommandManager.java
@@ -505,12 +505,7 @@ public class CommandManager extends LeTrainProgramBaseVisitor<Object> {
             log.warn("[DSL] Train not found for '{}'", ctx.trainRef().getText());
             return null;
         }
-        // Ensure autopilot exists and has a pathfinder
-        if (train.getAutopilot() == null) {
-            train.setAutopilot(new letrain.itinerary.impl.AutoPilotImpl(
-                new TrainAutoPilotContext(train),
-                train.actionManager));
-        }
+        // Autopilot is always instantiated. Set pathfinder and assign itinerary
         if (model.getRailwayGraph() != null) {
             train.getAutopilot().setPathfinder(
                 new letrain.itinerary.AStarPathfinder(model.getRailwayGraph()));

--- a/src/main/java/letrain/itinerary/impl/TrainActionManager.java
+++ b/src/main/java/letrain/itinerary/impl/TrainActionManager.java
@@ -237,7 +237,7 @@ public class TrainActionManager implements letrain.itinerary.TrainActionManager 
     @Override
     public void acquireInitialLocks() {
 
-        if (this.train.getModel() != null && this.train.isAutoMode() && this.train.getAutopilot() != null) {
+        if (this.train.getModel() != null && this.train.isAutoMode()) {
             Linker head = this.train.getPhysicalFront();
             if (head != null && head.getTrack() instanceof RailTrack) {
                 letrain.segments.Segment currentSeg = this.train.getModel().getRailwayGraph().getSegment((RailTrack) head.getTrack());

--- a/src/main/java/letrain/mvp/impl/TrainMixin.java
+++ b/src/main/java/letrain/mvp/impl/TrainMixin.java
@@ -54,7 +54,4 @@ public abstract class TrainMixin {
 
     @JsonProperty("autopilot")
     AutoPilot autopilot;
-
-    @JsonProperty("autoMode")
-    boolean autoMode;
 }

--- a/src/main/java/letrain/vehicle/rail/impl/Locomotive.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Locomotive.java
@@ -244,9 +244,6 @@ public class Locomotive extends Linker implements Tractor {
         // Speed change in auto mode → switch to manual
         if (getTrain() != null && getTrain().isAutoMode()) {
             getTrain().setAutoMode(false);
-            if (getTrain().getAutopilot() != null) {
-                getTrain().getAutopilot().deactivate();
-            }
         }
         setTargetSpeed(this.targetSpeed + 1);
     }
@@ -255,9 +252,6 @@ public class Locomotive extends Linker implements Tractor {
         // Speed change in auto mode → switch to manual
         if (getTrain() != null && getTrain().isAutoMode()) {
             getTrain().setAutoMode(false);
-            if (getTrain().getAutopilot() != null) {
-                getTrain().getAutopilot().deactivate();
-            }
         }
         setTargetSpeed(this.targetSpeed - 1);
     }

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -47,7 +47,6 @@ public class Train implements Renderable {
     private letrain.vehicle.rail.Trip trip;
 
     private Tractor directorLinker;
-    private boolean autoMode = false;
 
     private transient letrain.mvp.Model model;
     public transient List<TrainEventListener> scriptTrainListeners;
@@ -79,6 +78,7 @@ public class Train implements Renderable {
         this.movementManager = new letrain.vehicle.rail.impl.TrainMovementManager(this);
         this.safetyManager = new letrain.vehicle.rail.impl.TrainSafetyManager(this);
         this.actionManager = new letrain.itinerary.impl.TrainActionManager(this);
+        this.autopilot = new letrain.itinerary.impl.AutoPilotImpl(new TrainAutoPilotContext(this), this.actionManager);
     }
 
     /**
@@ -119,31 +119,31 @@ public class Train implements Renderable {
     }
 
     public boolean isAutoMode() {
-        return autoMode;
+        return autopilot.mode() != letrain.itinerary.AutoPilot.Mode.IDLE;
     }
 
     public void setAutoMode(boolean autoMode) {
-        this.autoMode = autoMode;
-        if (!autoMode && autopilot != null) {
-            autopilot.deactivate(); // Apaga el piloto automático automáticamente si pasamos a manual
+        if (autoMode) {
+            autopilot.activate();
+        } else {
+            autopilot.deactivate();
         }
     }
 
     public void toggleAutoMode() {
-        log.info("[TRAIN] toggleAutoMode() current={}", autoMode);
-        if (autoMode) {
-            autoMode = false;
-            if (autopilot != null)
-                autopilot.deactivate();
-        } else if (autopilot != null && autopilot.itinerary().isPresent()) {
-            autoMode = autopilot.activate();
-            if (autoMode) {
+        boolean currentAutoMode = isAutoMode();
+        log.info("[TRAIN] toggleAutoMode() current={}", currentAutoMode);
+        if (currentAutoMode) {
+            autopilot.deactivate();
+        } else if (autopilot.itinerary().isPresent()) {
+            boolean activated = autopilot.activate();
+            if (activated) {
                 this.actionManager.checkWaypointArrival();
                 this.actionManager.acquireInitialLocks();
                 this.actionManager.checkWaypointArrival();
             }
         }
-        log.info("[TRAIN] toggleAutoMode → autoMode={}", autoMode);
+        log.info("[TRAIN] toggleAutoMode → autoMode={}", isAutoMode());
     }
 
     public void setAutopilot(letrain.itinerary.AutoPilot ap) {
@@ -290,7 +290,7 @@ public class Train implements Renderable {
                 });
             }
             this.actionManager.checkWaypointArrival();
-            if (autoMode && autopilot != null) {
+            if (isAutoMode()) {
                 autopilot.onSegmentEntered(safetyManager.getCurrentSegment());
             }
         } finally {
@@ -367,15 +367,15 @@ public class Train implements Renderable {
         this.trainCouplingManager = new letrain.vehicle.rail.impl.TrainCouplingManager();
         this.safetyManager = new letrain.vehicle.rail.impl.TrainSafetyManager(this);
         this.movementManager = new letrain.vehicle.rail.impl.TrainMovementManager(this);
-        if (this.autopilot != null) {
-            if (this.autopilot instanceof letrain.itinerary.impl.AutoPilotImpl) {
-                ((letrain.itinerary.impl.AutoPilotImpl) this.autopilot).reinitialize(
-                        new TrainAutoPilotContext(this), this.actionManager);
-            }
-            if (getModel() != null && getModel().getRailwayGraph() != null) {
-                this.autopilot.setPathfinder(
-                        new letrain.itinerary.AStarPathfinder(getModel().getRailwayGraph()));
-            }
+        if (this.autopilot == null) {
+            this.autopilot = new letrain.itinerary.impl.AutoPilotImpl(new TrainAutoPilotContext(this), this.actionManager);
+        } else if (this.autopilot instanceof letrain.itinerary.impl.AutoPilotImpl) {
+            ((letrain.itinerary.impl.AutoPilotImpl) this.autopilot).reinitialize(
+                    new TrainAutoPilotContext(this), this.actionManager);
+        }
+        if (getModel() != null && getModel().getRailwayGraph() != null) {
+            this.autopilot.setPathfinder(
+                    new letrain.itinerary.AStarPathfinder(getModel().getRailwayGraph()));
         }
     }
 
@@ -615,7 +615,7 @@ public class Train implements Renderable {
 
     public void notifySegmentEntered(letrain.segments.Segment newSegment) {
         this.actionManager.checkWaypointArrival();
-        if (autoMode && autopilot != null) {
+        if (isAutoMode()) {
             log.info("Train {} notifySegmentEntered: notifying autopilot", id);
             autopilot.onSegmentEntered(newSegment);
         }

--- a/src/main/java/letrain/vehicle/rail/impl/TrainSafetyManager.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainSafetyManager.java
@@ -191,7 +191,7 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
         boolean shouldLockNext = true;
         if (train.isAutoMode()) {
             letrain.itinerary.AutoPilot ap = train.getAutopilot();
-            if (ap == null || ap.mode() == letrain.itinerary.AutoPilot.Mode.WAITING || ap.mode() == letrain.itinerary.AutoPilot.Mode.IDLE) {
+            if (ap.mode() == letrain.itinerary.AutoPilot.Mode.WAITING || ap.mode() == letrain.itinerary.AutoPilot.Mode.IDLE) {
                 shouldLockNext = false;
             }
         }
@@ -274,7 +274,7 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
         boolean shouldLockNext = true;
         if (train.isAutoMode()) {
             letrain.itinerary.AutoPilot ap = train.getAutopilot();
-            if (ap == null || ap.mode() == letrain.itinerary.AutoPilot.Mode.WAITING || ap.mode() == letrain.itinerary.AutoPilot.Mode.IDLE) {
+            if (ap.mode() == letrain.itinerary.AutoPilot.Mode.WAITING || ap.mode() == letrain.itinerary.AutoPilot.Mode.IDLE) {
                 shouldLockNext = false;
             }
         }
@@ -387,10 +387,9 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
         try {
             Segment topological = findNextSegmentTopological(head, graph);
             letrain.itinerary.AutoPilot ap = train.getAutopilot();
-            log.info("Train {} findNextSegment: ap={}, apMode={}, topological={}", train.getId(),
-                    ap != null ? "present" : "null", ap != null ? ap.mode() : "N/A",
-                    topological != null ? topological.getId() : "null");
-            if (ap != null && (ap.mode() == letrain.itinerary.AutoPilot.Mode.FOLLOWING || ap.mode() == letrain.itinerary.AutoPilot.Mode.WAITING)) {
+            log.info("Train {} findNextSegment: apMode={}, topological={}", train.getId(),
+                    ap.mode(), topological != null ? topological.getId() : "null");
+            if (ap.mode() == letrain.itinerary.AutoPilot.Mode.FOLLOWING || ap.mode() == letrain.itinerary.AutoPilot.Mode.WAITING) {
                 // Consultamos la ruta real planificada del piloto automático
                 List<Segment> route = ap.currentRoute();
                 int index = route.indexOf(currentSegment);
@@ -526,9 +525,7 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
             Segment oldNext = nextSegment;
             nextSegment = sAlt;
             letrain.itinerary.AutoPilot ap = train.getAutopilot();
-            if (ap != null) {
-                ap.replaceRouteSegment(oldNext, sAlt);
-            }
+            ap.replaceRouteSegment(oldNext, sAlt);
             return true;
         }
 
@@ -538,9 +535,6 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
 
     private boolean segmentHasPendingWaypoints(Segment segment) {
         letrain.itinerary.AutoPilot ap = train.getAutopilot();
-        if (ap == null) {
-            return false;
-        }
         java.util.Optional<letrain.itinerary.Itinerary> itinOpt = ap.itinerary();
         if (itinOpt.isEmpty()) {
             return false;

--- a/src/test/java/letrain/SerializationTest.java
+++ b/src/test/java/letrain/SerializationTest.java
@@ -357,11 +357,11 @@ class SerializationTest {
             new TrainAutoPilotContext(original), original.actionManager
         );
         ap.setItinerary(itinerary);
+        original.setAutopilot(ap);
+        ap.setPathfinder(org.mockito.Mockito.mock(letrain.itinerary.SegmentPathfinder.class));
+        original.setAutoMode(true);
         ap.setWaitTicks(42);
         ap.setPendingCommands(java.util.List.of(letrain.itinerary.WaypointCommand.speed(5)));
-
-        original.setAutopilot(ap);
-        original.setAutoMode(true);
 
         // Serialize and Deserialize
         byte[] data = serialize(original);
@@ -374,7 +374,7 @@ class SerializationTest {
 
         letrain.itinerary.AutoPilot restoredAp = restored.getAutopilot();
         assertNotNull(restoredAp);
-        assertEquals(letrain.itinerary.AutoPilot.Mode.IDLE, restoredAp.mode());
+        assertEquals(letrain.itinerary.AutoPilot.Mode.FOLLOWING, restoredAp.mode());
 
         letrain.itinerary.Itinerary restoredItin = restoredAp.itinerary().orElse(null);
         assertNotNull(restoredItin);


### PR DESCRIPTION
This PR refactors the Train entity to always instantiate its autopilot system in the constructor, removing any redundant null checks across the codebase. It also removes the  boolean state from the  class and instead delegates it dynamically to the autopilot's operational status ().