### PR TITLE
Refactor: train event system cleanup

### DIFF
--- a/docs/Index.md
+++ b/docs/Index.md
@@ -17,6 +17,9 @@ Bienvenido a la documentación técnica de **LeTrain**. Esta wiki está diseñad
 - [[vehicles/Physics|Física de Movimiento y Colisiones]]
 - [[vehicles/CargoSystems|Sistema de Carga y Economía]]
 
+## ⚡ Sistema de Eventos
+- [[events/TrainEvents|Eventos de Tren y TrainEventDispatcher]]
+
 ## 🧭 Navegación y Automatización
 - [[navigation/AStarPathfinder|Navegación Autónoma (Funcionalidad Planificada)]]
 - [[adr/ADR-009-Itinerary-Editor|ADR-009: Editor de Itinerarios (DSL)]]

--- a/docs/events/TrainEvents-Review.md
+++ b/docs/events/TrainEvents-Review.md
@@ -1,0 +1,252 @@
+[ [Índice] ] [[docs/events/TrainEvents|⬅️ Sistema de Eventos]] · [[docs/Index|⬅️ Volver al Índice]]
+
+# Revisión: Sistema de Eventos de Tren
+
+Puntos detectados tras analizar `TrainEventDispatcher`, `Train.java` y los consumidores de eventos. Índice:
+
+1. [[#1 Inconsistencia en null-safety|Inconsistencia en null-safety]]
+2. [[#2 Reentrancia parcial|Reentrancia parcial]]
+3. [[#3 Exposición de listas internas|Exposición de listas internas]]
+4. [[#4 Guard l sensor huérfano|Guard `l != sensor` huérfano]]
+5. [[#5 SegmentOccupied sin llamante|`SegmentOccupied` sin llamante]]
+6. [[#6 Sin interfaz para el dispatcher|Sin interfaz para el dispatcher]]
+7. [[#7 Orden script core no documentado|Orden script/core no documentado]]
+8. [[#8 Código repetido en notify methods|Código repetido en notify methods]]
+
+---
+
+## 1. Inconsistencia en null-safety
+
+**Archivo**: `TrainEventDispatcher.java`
+
+**Problema**: Los métodos `notifyXxx` chequean `if (scriptTrainListeners != null)` contra el campo directamente, pero los getters (`getScriptTrainListeners()`) ya hacen lazy init y nunca devuelven null. Tras deserialización, `postLoadInit()` ya garantiza que las listas no sean null.
+
+```java
+// notifyXxx - chequea el campo directamente
+public void notifySpeedChanged(int speed) {
+    if (scriptTrainListeners != null) {          // ← redundante si postLoadInit() funciona
+        for (TrainEventListener l : scriptTrainListeners) {
+            l.onSpeedChanged(speed);
+        }
+    }
+    if (coreTrainListeners != null) {            // ← redundante
+        for (TrainEventListener l : coreTrainListeners) {
+            l.onSpeedChanged(speed);
+        }
+    }
+}
+
+// add/remove - usa el getter con lazy init
+public void addScriptTrainEventListener(TrainEventListener listener) {
+    getScriptTrainListeners().add(listener);     // ← getter nunca devuelve null
+}
+```
+
+**Posible mejora**: Usar los getters también en los notify (o eliminar los null-checks y confiar en `postLoadInit`).
+
+---
+
+## 2. Reentrancia parcial
+
+**Archivos**: `Train.java` (líneas 226-254), `TrainEventDispatcher.java`
+
+**Problema**: Solo `notifyEnterSensor` y `notifyExitSensor` tienen guarda de reentrancia en `Train.java`. El resto de notificaciones (`link`, `unlink`, `crash`, `contact`, `speedChanged`, `senseChanged`) no.
+
+```java
+// Train.java - solo sensor events tienen guarda
+public void notifyEnterSensor(Sensor sensor, boolean isForward) {
+    if (isNotifying) return;       // ← única guarda
+    isNotifying = true;
+    try {
+        this.eventDispatcher.notifyEnterSensor(sensor, isForward);
+    } finally {
+        isNotifying = false;
+    }
+}
+
+// El resto NO tienen guarda
+public void notifyLink() {
+    this.eventDispatcher.notifyLink();
+    // Si un listener de onLink llama a train.notifyLink(), recursión infinita
+}
+```
+
+**Riesgo**: Si un listener de `onLink` (por ejemplo) vuelve a llamar `train.notifyLink()`, se produce recursión infinita. `CopyOnWriteArrayList` sobrevive, pero el stack se desborda.
+
+**Posible mejora**: Aplicar la misma guarda `isNotifying` a todos los notify, o al menos a los que pueden tener loops (link/unlink/crash).
+
+---
+
+## 3. Exposición de listas internas
+
+**Archivo**: `TrainEventDispatcher.java`
+
+**Problema**: `getScriptTrainListeners()` y `getCoreTrainListeners()` devuelven la lista mutable directamente, permitiendo modificaciones sin pasar por `add/remove`.
+
+```java
+// Código actual - expone la lista interna
+public List<TrainEventListener> getScriptTrainListeners() {
+    if (scriptTrainListeners == null) {
+        scriptTrainListeners = new CopyOnWriteArrayList<>();
+    }
+    return scriptTrainListeners;  // ← cualquiera puede hacer .clear(), .add(), etc.
+}
+```
+
+**Quién usa estos getters**: `Train.java` los llama. Si algún otro código los usa para modificar la lista, se salta el control de `add/remove`.
+
+**Posible mejora**: Devolver `Collections.unmodifiableList()` para lectura, y forzar el uso de `add/remove` para escritura.
+
+---
+
+## 4. Guard `l != sensor` huérfano
+
+**Archivo**: `TrainEventDispatcher.java`
+
+**Problema**: En `notifyEnterSensor` y `notifyExitSensor` hay una guarda `if (l != sensor)` que evita que el sensor que origina el evento se auto-notifique. Originalmente existía porque `Station` (que extiende `Sensor`) implementaba `TrainEventListener` y se registraba como core listener. Desde que eliminamos eso, ningún objeto `Sensor` está en las listas de listeners, por lo que la guarda nunca se cumple.
+
+```java
+public void notifyEnterSensor(Sensor sensor, boolean isForward) {
+    scriptTrainListeners.forEach(l -> {
+        if (l != sensor) {         // ← nunca es false, ningún Sensor es TrainEventListener
+            l.onSensorEnter(train, isForward);
+        }
+    });
+}
+```
+
+**Posible mejora**: Eliminar la guarda (simplifica el código). Si en el futuro alguien registra un Sensor como listener, habría que valorar si la auto-exclusión es necesaria.
+
+---
+
+## 5. `SegmentOccupied` sin llamante
+
+**Archivo**: `TrainEventDispatcher.java`
+
+**Problema**: El método `notifySegmentOccupied` está implementado pero no se llama desde ningún sitio.
+
+```java
+public void notifySegmentOccupied(Segment segment) {
+    if (scriptTrainListeners != null) {
+        scriptTrainListeners.forEach(l -> l.onSegmentOccupied(train, segment));
+    }
+    if (coreTrainListeners != null) {
+        coreTrainListeners.forEach(l -> l.onSegmentOccupied(train, segment));
+    }
+}
+```
+
+**Búsqueda**: No hay `train.notifySegmentOccupied()` ni ninguna llamada a este método en toda la base de código.
+
+**Posible mejora**: Eliminar el método (junto con `onSegmentOccupied` de `TrainEventListener`) si no hay planes de usarlo, o implementar el llamante si es necesario.
+
+---
+
+## 6. Sin interfaz para el dispatcher
+
+**Archivo**: `TrainEventDispatcher.java`
+
+**Problema**: El proyecto tiene interfaces para casi todo (por convención en `project-guidelines.instructions.md`), pero `TrainEventDispatcher` es una clase concreta sin interfaz.
+
+```java
+// Clase concreta - difícil de mockear
+public class TrainEventDispatcher {
+    // ...
+}
+```
+
+**Consecuencias**:
+- No se puede mockear en tests unitarios de `Train` o `TrainMovementManager`.
+- No se puede reemplazar la implementación sin modificar `Train`.
+- `Train` queda acoplado a la implementación concreta.
+
+**Posible mejora**: Extraer interfaz `TrainEventDispatcher` (o renombrar la actual a `TrainEventDispatcherImpl` y crear la interfaz).
+
+---
+
+## 7. Orden script/core no documentado
+
+**Archivo**: `TrainEventDispatcher.java`
+
+**Problema**: Todos los notify recorren primero script y luego core, pero esta precedencia no está documentada ni es configurable.
+
+```java
+public void notifyXxx(...) {
+    // Siempre: script primero
+    if (scriptTrainListeners != null) {
+        for (TrainEventListener l : scriptTrainListeners) { ... }
+    }
+    // Siempre: core después
+    if (coreTrainListeners != null) {
+        for (TrainEventListener l : coreTrainListeners) { ... }
+    }
+}
+```
+
+**Implicación**: Un listener core que deba ejecutarse *antes* que los scripts (ej: seguridad, logging de auditoría) no tiene forma de hacerlo.
+
+**Posible mejora**: Documentar la precedencia como un contrato, o permitir orden configurable, o separar en interfaces distintas (`ScriptTrainEventListener` y `CoreTrainEventListener`) para evitar ambigüedad.
+
+---
+
+## 8. Código repetido en notify methods
+
+**Archivo**: `TrainEventDispatcher.java`
+
+**Problema**: Los 9 métodos `notifyXxx` siguen exactamente el mismo patrón: recorrer script, recorrer core, con el mismo null-check. Solo cambia el método invocado y sus argumentos.
+
+```java
+// 9 variaciones de:
+public void notifyXxx(...args...) {
+    if (scriptTrainListeners != null) {
+        for (TrainEventListener l : scriptTrainListeners) {
+            l.onXxx(...args...);
+        }
+    }
+    if (coreTrainListeners != null) {
+        for (TrainEventListener l : coreTrainListeners) {
+            l.onXxx(...args...);
+        }
+    }
+}
+```
+
+**Posible mejora**: Un método auxiliar genérico:
+
+```java
+private void notifyAll(Consumer<TrainEventListener> notification) {
+    if (scriptTrainListeners != null) {
+        scriptTrainListeners.forEach(notification);
+    }
+    if (coreTrainListeners != null) {
+        coreTrainListeners.forEach(notification);
+    }
+}
+```
+
+Y cada notify público sería:
+
+```java
+public void notifySpeedChanged(int speed) {
+    notifyAll(l -> l.onSpeedChanged(speed));
+}
+```
+
+Esto elimina la repetición, centraliza el null-check y la decisión del orden script/core en un solo sitio.
+
+---
+
+## Resumen
+
+| # | Asunto | Impacto | Esfuerzo |
+|---|---|---|---|
+| 1 | Null-safety inconsistente | Bajo (defensivo, no bug) | Trivial |
+| 2 | Reentrancia parcial | Medio (posible stack overflow) | Bajo |
+| 3 | Listas expuestas | Bajo (encapsulación) | Trivial |
+| 4 | Guard `l != sensor` huérfano | Bajo (código muerto) | Trivial |
+| 5 | `SegmentOccupied` sin llamante | Bajo (código muerto) | Trivial |
+| 6 | Sin interfaz para dispatcher | Medio (testabilidad) | Medio |
+| 7 | Orden script/core no documentado | Bajo (diseño) | Bajo |
+| 8 | Código repetido | Bajo (mantenibilidad) | Bajo |
+
+**Prioridad sugerida**: 2 → 3 → 4+5+8 → 1 → 6 → 7

--- a/docs/events/TrainEvents.md
+++ b/docs/events/TrainEvents.md
@@ -1,0 +1,507 @@
+[ [Índice] ] [[docs/Index|⬅️ Volver al Índice]]
+
+# Sistema de Eventos de Tren
+
+El sistema de eventos de LeTrain sigue el patrón **Observer** multicapa para desacoplar los componentes del simulador. Cuando un tren se mueve, acopla, choca o pasa por un sensor, se disparan eventos que notifican tanto a componentes internos del sistema (audio, logging, economía) como a scripts de automatización del usuario.
+
+## Arquitectura General
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Train                                       │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │                  TrainEventDispatcher                        │   │
+│  │                                                              │   │
+│  │  ┌─────────────────────┐  ┌─────────────────────┐            │   │
+│  │  │ Script Listeners    │  │ Core Listeners      │            │   │
+│  │  │CopyOnWriteArrayList │  │ CopyOnWriteArrayList│            │   │
+│  │  │                     │  │                     │            │   │
+│  │  │  • CommandManager   │  │  • Model (logging)  │            │   │
+│  │  │  (automatización    │  │  • TerminalPresenter│            │   │
+│  │  │   del usuario)      │  │  • GraphicPresenter │            │   │
+│  │  │                     │  │  • Station          │            │   │
+│  │  └─────────────────────┘  └─────────────────────┘            │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              │ notifica a través de
+                              ▼
+                    ┌──────────────────┐
+                    │TrainEventListener│
+                    │(interfaz con     │
+                    │ métodos default) │
+                    └──────────────────┘
+```
+
+**Principio fundamental**: Los eventos **NO** se procesan en `tick()` ni `advance()`. El sistema es reactivo y event-driven: las acciones del tren (movimiento, colisiones, acoplamiento) disparan notificaciones que los listeners procesan fuera del bucle de física.
+
+## TrainEventDispatcher
+
+**Ubicación**: `src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java`
+
+El `TrainEventDispatcher` es el núcleo de la gestión de eventos de cada tren. Centraliza el registro y la notificación de eventos, separando los listeners en dos categorías:
+
+### Listener de Doble Nivel
+
+| Categoría | Tipo de Lista | Propósito | Ejemplos |
+|---|---|---|---|
+| **Script** | `CopyOnWriteArrayList<TrainEventListener>` | Automatización definida por el usuario (vía ANTLR) | `CommandManager` |
+| **Core** | `CopyOnWriteArrayList<TrainEventListener>` | Componentes internos del sistema | `Model` (logging), `TerminalPresenter` (audio), `GraphicPresenter` (audio), `Station` |
+
+### Ciclo de Vida del Dispatcher
+
+```
+Creación del Tren
+       │
+       ▼
+new TrainEventDispatcher(train)
+       │
+       ▼
+Registro de listeners (addScriptTrainEventListener / addCoreTrainEventListener)
+       │
+       ▼
+  ┌────┴────┐
+  │         │
+Evento    Serialización (Jackson)
+  │         │
+  ▼         ▼
+notifyXxx()  postLoadInit()
+  │         │
+  ▼         ▼
+Recorre listas  Re-inicializa listas
+y llama a cada  (CopyOnWriteArrayList)
+listener       si son null
+```
+
+### Métodos de Notificación del Dispatcher
+
+Cada método recorre **ambas** listas (script y core) en orden:
+
+| Método | Evento | Método en TrainEventListener |
+|---|---|---|
+| `notifySpeedChanged(int speed)` | Cambio de velocidad | `onSpeedChanged(speed)` |
+| `notifySenseChanged(boolean forward)` | Cambio de dirección (marcha atrás) | `onSenseChanged(forward)` |
+| `notifyLink()` | Acoplamiento con otro tren | `onLink(train)` |
+| `notifyUnlink()` | Desacoplamiento | `onUnlink(train)` |
+| `notifyEnterSensor(Sensor, boolean)` | Entrada a sensor | `onSensorEnter(train, isForward)` |
+| `notifyExitSensor(Sensor, boolean)` | Salida de sensor | `onSensorExit(train, isForward)` |
+| `notifySegmentOccupied(Segment)` | Ocupación de segmento de vía | `onSegmentOccupied(train, segment)` |
+| `notifyContact(Point, int)` | Contacto a baja velocidad (< 5) | `onContact(train, pos, speed)` |
+| `notifyCrash(Point, int)` | Colisión a alta velocidad (>= 5) | `onCrash(train, pos, speed)` |
+
+---
+
+## TrainEventListener
+
+**Ubicación**: `src/main/java/letrain/vehicle/rail/TrainEventListener.java`
+
+```java
+public interface TrainEventListener extends Serializable {
+    default void onSpeedChanged(int speed) {}
+    default void onSenseChanged(boolean forward) {}
+    default void onLink(Train train) {}
+    default void onUnlink(Train train) {}
+    default void onCrash(Train train, Point pos, int speed) {}
+    default void onContact(Train train, Point pos, int speed) {}
+    default void onSensorEnter(Train train, boolean isForward) {}
+    default void onSensorExit(Train train, boolean isForward) {}
+    default void onSegmentOccupied(Train train, Segment segment) {}
+}
+```
+
+- **Todos los métodos son `default`**: los listeners implementan solo los que necesitan.
+- **Extiende `Serializable`**: permite que los listeners script se serialicen con el estado.
+
+---
+
+## Flujo Completo de Eventos
+
+### 1. Eventos de Movimiento y Sensor
+
+El origen de la mayoría de eventos está en `TrainMovementManager.moveLinkers()`. Cuando los linkers (vagones individuales) avanzan por las celdas, se detectan sensores, bifurcaciones, semáforos y segmentos.
+
+```
+TrainMovementManager.moveLinkers()
+  │
+  ├── Salida de celda (último linker)
+  │   ├── sensorExit.onExitTrain(train)          → Sensor (SensorEventListener)
+  │   ├── currentTrack.getSemaphore().onExitTrain() → Semáforo
+  │   └── fork.onExitTrain(train)                  → Bifurcación
+  │
+  ├── Entrada a nueva celda (primer linker)
+  │   ├── train.notifySegmentEntered(newSegment) → SegmentLogger
+  │   ├── sensorEnter.onEnterTrain(train)         → Sensor (SensorEventListener)
+  │   │       └── Sensor.onSensorEnter() llama a:
+  │   │           ├── dispatcher.notifyEnterSensor()  → TrainEventListener.onSensorEnter()
+  │   │           └── sensor.listeners.onEnterTrain() → SensorEventListener.onEnterTrain()
+  │   ├── nextTrack.getSemaphore().onEnterTrain() → Semáforo
+  │   └── fork.onEnterTrain(train)                → Bifurcación
+  │
+  └── Colisión / Callejón sin salida
+      ├── speed >= 5 → train.notifyCrash(pos, speed)
+      └── speed < 5  → train.notifyContact(pos, speed)
+```
+
+### 2. Eventos de Sensor en Detalle
+
+El `Sensor` es un dispositivo de vía que implementa **dos interfaces de evento simultáneamente**:
+
+```
+Sensor implements SensorEventListener, TrainEventListener
+```
+
+Cuando un tren entra en una celda con sensor:
+
+```
+1. TrainMovementManager llama a sensorEnter.onEnterTrain(train)
+2. Sensor.onEnterTrain(train):
+   a. train.notifyEnterSensor(this, isForward)
+      → dispatcher recorre listeners
+      → llama a onSensorEnter() para cada listener
+      → PERO salta al propio sensor (l != sensor)
+         para evitar auto-recibirse
+   b. sensorListeners.forEach(l -> l.onEnterTrain(train))
+      → SensorEventListener.onEnterTrain() (otros sensores, estaciones, etc.)
+```
+
+### 3. Eventos de Velocidad
+
+```
+Locomotive.setCurrentSpeed(int speed)
+  │
+  └── train.notifySpeedChanged(this.currentSpeed)
+        │
+        └── dispatcher.notifySpeedChanged(speed)
+              │
+              ├── Script listeners: onSpeedChanged(speed)
+              └── Core listeners:  onSpeedChanged(speed)
+```
+
+Cada vez que cambia la velocidad de una locomotora, se notifica a todos los listeners.
+
+### 4. Eventos de Cambio de Dirección
+
+```
+Locomotive.toggleReversed()
+  │
+  └── train.notifySenseChanged(!isReversed())
+        │
+        └── dispatcher.notifySenseChanged(forward)
+```
+
+### 5. Eventos de Acoplamiento/Desacoplamiento
+
+```
+TrainCouplingManager.doJoin()
+  │
+  ├── Lógica de acoplamiento físico
+  └── train.notifyLink()
+        │
+        └── dispatcher.notifyLink()
+              ├── Script: onLink(train)
+              └── Core:   onLink(train)
+
+TrainCouplingManager.doUnlink()
+  │
+  ├── Lógica de desacoplamiento
+  └── train.notifyUnlink()
+        │
+        └── dispatcher.notifyUnlink()
+              ├── Script: onUnlink(train)
+              └── Core:   onUnlink(train)
+```
+
+### 6. Eventos de Ocupación de Segmento
+
+```
+TrainActionManager.notifySegmentOccupied(Segment segment)
+  │
+  └── train.notifySegmentOccupied(segment)
+        │
+        └── dispatcher.notifySegmentOccupied(segment)
+              ├── Script: onSegmentOccupied(train, segment)
+              └── Core:   onSegmentOccupied(train, segment)
+```
+
+---
+
+## Eventos de Dispositivos de Vía (Track Device Events)
+
+Además del sistema `TrainEventListener`, cada dispositivo de vía tiene su propio sistema de eventos con sus propias interfaces:
+
+### Sensor
+
+`SensorEventListener` → `src/main/java/letrain/track/SensorEventListener.java`
+
+```java
+public interface SensorEventListener extends Serializable {
+    default void onExitTrain(Train train, boolean isForward) {}
+    default void onEnterTrain(Train train, boolean isForward) {}
+}
+```
+
+**Registro**: `Sensor.addSensorListener(SensorEventListener)`
+
+### Estación
+
+`StationEventListener` → `src/main/java/letrain/track/StationEventListener.java`
+
+```java
+public interface StationEventListener extends Serializable {
+    default void onEnterTrain(Train train, boolean isForward) {}
+    default void onExitTrain(Train train, boolean isForward) {}
+    default void onLoad(Train train) {}
+    default void onUnload(Train train) {}
+    default void onStartLoad(Train train) {}
+    default void onEndLoad(Train train) {}
+    default void onStartUnload(Train train) {}
+    default void onEndUnload(Train train) {}
+    default void onLink(Train train) {}
+    default void onUnlink(Train train) {}
+}
+```
+
+**Registro**: `Station.addStationListener(StationEventListener)`
+
+**Nota**: `Station` también implementa `TrainEventListener` y se registra como **core listener** del tren cuando este entra, permitiéndole reaccionar a acoplamientos/desacoplamientos dentro de sus límites.
+
+### Bifurcación (Fork)
+
+`ForkEventListener` → `src/main/java/letrain/track/ForkEventListener.java`
+
+```java
+public interface ForkEventListener extends Serializable {
+    default void onEnterTrain(Train train, boolean isForward) {}
+    default void onExitTrain(Train train, boolean isForward) {}
+    default void onDirectionChanged(boolean normal) {}
+}
+```
+
+**Registro**: `ForkRailTrack.addForkListener(ForkEventListener)`
+
+### Semáforo
+
+`SemaphoreEventListener` → `src/main/java/letrain/track/SemaphoreEventListener.java`
+
+```java
+public interface SemaphoreEventListener extends Serializable {
+    default void onOpen() {}
+    default void onClosed() {}
+    default void onEnterTrain(Train train, boolean isForward) {}
+    default void onExitTrain(Train train, boolean isForward) {}
+}
+```
+
+**Registro**: `RailSemaphore.addSemaphoreListener(SemaphoreEventListener)`
+
+---
+
+## Ejemplo de Registro de Listeners
+
+### Sistema Core (Model.java)
+
+```java
+// Registro de listeners core a nivel global
+// Model.addCoreTrainEventListener() los propaga a todos los trenes
+public void addCoreTrainEventListener(TrainEventListener listener) {
+    if (trainEventListeners == null) {
+        trainEventListeners = new CopyOnWriteArrayList<>();
+    }
+    trainEventListeners.add(listener);
+    // También se registra en trenes existentes
+    for (Locomotive loc : locomotives) {
+        loc.getTrain().addCoreTrainEventListener(listener);
+    }
+}
+```
+
+### Estación (autoregistro dinámico)
+
+```java
+// Station.java — se registra como core listener cuando un tren entra
+@Override
+public void onEnterTrain(Train train, boolean isForward) {
+    // ...
+    train.addCoreTrainEventListener(this);  // se suscribe a eventos del tren
+    notifyEnterTrain(train, isForward);
+}
+
+@Override
+public void onExitTrain(Train train, boolean isForward) {
+    train.removeCoreTrainEventListener(this);  // se desuscribe al salir
+    notifyExitTrain(train, isForward);
+}
+```
+
+### Sistema de Audio (TerminalPresenter)
+
+```java
+// TerminalPresenter.java implementa TrainEventListener
+// Se registra como core listener para reproducir sonidos
+train.addCoreTrainEventListener(this);
+
+// Responde solo a eventos que requieren audio:
+@Override
+public void onCrash(Train train, Point pos, int speed) {
+    audioEngine.play("explosion", pos);
+    // detiene sintetizadores de locomotora
+}
+```
+
+### Automatización (CommandManager)
+
+```java
+// CommandManager.java — se registra como script listener
+// para ejecutar comandos definidos por el usuario
+// cuando el tren pasa por sensores, se acopla, etc.
+train.addScriptTrainEventListener(commandListener);
+
+// El listener checkea si hay comandos definidos
+// para ese sensor/evento y los ejecuta
+```
+
+---
+
+## Serialización y PostLoad
+
+Los listeners **no se serializan** en su totalidad:
+
+```mermaid
+sequenceDiagram
+    participant SaveGame as Guardar Partida (JSON)
+    participant Jackson as Jackson Serializer
+    participant Model as Model
+    participant Train as Train
+
+    SaveGame->>Jackson: serialize(Model)
+    Note over Jackson: TrainEventListeners<br/>tienen @JsonIgnore
+    Jackson->>Train: guarda estado (speed, pos, etc.)
+    Note over Train: NO guarda scriptTrainListeners<br/>NO guarda coreTrainListeners
+    Jackson-->>SaveGame: JSON sin listeners
+
+    Note over SaveGame: ─── Cargar Partida ───
+
+    SaveGame->>Jackson: deserialize(JSON)
+    Jackson-->>Model: Model con listeners=null
+    Model->>Model: postLoadInit()
+    Model->>Model: reestablishSystemListeners()
+
+    Note over Model: Reconstruye listeners de:<br/>• sensores<br/>• bifurcaciones<br/>• estaciones<br/>• semáforos
+
+    Model->>Train: postLoadInit() en cada tren
+    Train->>TrainEventDispatcher: postLoadInit()
+    Note over TrainEventDispatcher: Re-inicializa listas si son null
+```
+
+**Puntos clave**:
+- `TrainEventListeners` tiene `@JsonIgnore` en `Model.java`
+- `postLoadInit()` en `TrainEventDispatcher` usa `SerializationHelper.ensureListInitializedConcurrent()` para re-crear las listas
+- Los listeners `core` del sistema se re-registran en `Model.reestablishSystemListeners()`
+- Los listeners `script` (automatización del usuario) deben re-cargarse desde el script original
+
+---
+
+## Diagrama de Clases del Sistema de Eventos
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        TrainEventListener (interfaz)                    │
+│  + onSpeedChanged(int)                                                  │
+│  + onSenseChanged(boolean)                                              │
+│  + onLink(Train)                                                        │
+│  + onUnlink(Train)                                                      │
+│  + onCrash(Train, Point, int)                                           │
+│  + onContact(Train, Point, int)                                         │
+│  + onSensorEnter(Train, boolean)                                        │
+│  + onSensorExit(Train, boolean)                                         │
+│  + onSegmentOccupied(Train, Segment)                                    │
+└─────────────────────────────────────────────────────────────────────────┘
+            ▲                    ▲                     ▲
+            │                    │                     │
+   ┌────────┴────────┐  ┌───────┴───────┐   ┌────────┴──────────┐
+   │     Model       │  │ Terminal/     │   │  CommandManager   │
+   │  (logging/econ) │  │ GraphicPresent│   │  (script user)    │
+   │                 │  │  (audio)      │   │                   │
+   │ Core listener   │  │  Core listener│   │  Script listener  │
+   └─────────────────┘  └───────────────┘   └───────────────────┘
+
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    Interfaces de Dispositivos de Vía                    │
+├─────────────────┬─────────────────┬──────────────────┬──────────────────┤
+│ SensorEvent     │ StationEvent    │ ForkEvent        │ SemaphoreEvent   │
+│ Listener        │ Listener        │ Listener         │ Listener         │
+│                 │                 │                  │                  │
+│ + onEnterTrain  │ + onEnterTrain  │ + onEnterTrain   │ + onOpen         │
+│ + onExitTrain   │ + onExitTrain   │ + onExitTrain    │ + onClosed       │
+│                 │ + onLoad        │ + onDirChanged   │ + onEnterTrain   │
+│                 │ + onUnload      │                  │ + onExitTrain    │
+│                 │ + onStartLoad   │                  │                  │
+│                 │ + onEndLoad     │                  │                  │
+│                 │ + onStartUnload │                  │                  │
+│                 │ + onEndUnload   │                  │                  │
+│                 │ + onLink        │                  │                  │
+│                 │ + onUnlink      │                  │                  │
+└─────────────────┴─────────────────┴──────────────────┴──────────────────┘
+```
+
+---
+
+## Relación entre Interfaces de Evento
+
+Las interfaces de evento están organizadas en dos planos independientes:
+
+```
+PLANO 1: Eventos de Tren (TrainEventListener)
+  Emisor: Train → TrainEventDispatcher
+  Propósito: Notificar cambios de estado del tren a componentes del sistema y scripts
+
+PLANO 2: Eventos de Dispositivo de Vía (Sensor/Station/Fork/Semaphore)
+  Emisor: Dispositivo de vía → su propia lista de listeners
+  Propósito: Notificar eventos de tráfico en puntos específicos de la red
+
+PUENTE: Sensor implementa ambas interfaces
+  - Como TrainEventListener: recibe eventos de los trenes que lo atraviesan
+    (onSensorEnter desde el dispatcher del tren)
+  - Como emisor: notifica a sus propios SensorEventListener
+    (otros dispositivos interesados en ese punto de la vía)
+```
+
+---
+
+## Invariantes y Buenas Prácticas
+
+1. **Nunca modificar listeners desde dentro de una notificación**: Usar `CopyOnWriteArrayList` para permitir iteración segura aunque un listener se añada/elimine durante la notificación.
+
+2. **Auto-exclusión**: En `notifyEnterSensor` y `notifyExitSensor`, el sensor que origina el evento se excluye de la notificación (`if (l != sensor)`) para evitar ciclos.
+
+3. **Listeners transitorios**: Los listeners no se serializan. Tras cargar una partida, deben reestablecerse vía `postLoadInit()` y `reestablishSystemListeners()`.
+
+4. **Separación script/core**: Los listeners script (automatización del usuario) están aislados de los core (sistema). Los core nunca se eliminan por acciones del usuario.
+
+5. **Eventos acotados**: No hay un bus de eventos global. Cada tren tiene su propio dispatcher, y los dispositivos de vía tienen sus propias listas. Esto mantiene el acoplamiento bajo y el rendimiento predecible.
+
+---
+
+## Archivos Clave
+
+| Archivo | Ruta |
+|---|---|
+| TrainEventDispatcher | `src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java` |
+| TrainEventListener | `src/main/java/letrain/vehicle/rail/TrainEventListener.java` |
+| SensorEventListener | `src/main/java/letrain/track/SensorEventListener.java` |
+| StationEventListener | `src/main/java/letrain/track/StationEventListener.java` |
+| SemaphoreEventListener | `src/main/java/letrain/track/SemaphoreEventListener.java` |
+| ForkEventListener | `src/main/java/letrain/track/ForkEventListener.java` |
+| EventLogManager | `src/main/java/letrain/mvp/impl/EventLogManager.java` |
+| Train.java (firing) | `src/main/java/letrain/vehicle/rail/impl/Train.java` |
+| TrainMovementManager (origen) | `src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java` |
+| TrainCouplingManager | `src/main/java/letrain/vehicle/rail/impl/TrainCouplingManager.java` |
+| Sensor | `src/main/java/letrain/track/Sensor.java` |
+| Station | `src/main/java/letrain/track/Station.java` |
+| ForkRailTrack | `src/main/java/letrain/track/rail/ForkRailTrack.java` |
+| RailSemaphore | `src/main/java/letrain/track/RailSemaphore.java` |
+| Model.java | `src/main/java/letrain/mvp/impl/Model.java` |
+| CommandManager | `src/main/java/letrain/command/CommandManager.java` |
+| TerminalPresenter | `src/main/java/letrain/mvp/impl/terminal/TerminalPresenter.java` |
+| GraphicPresenter | `src/main/java/letrain/mvp/impl/graphic/GraphicPresenter.java` |

--- a/docs/events/TrainEvents.md
+++ b/docs/events/TrainEvents.md
@@ -16,10 +16,9 @@ El sistema de eventos de LeTrain sigue el patrón **Observer** multicapa para de
 │  │  │ Script Listeners    │  │ Core Listeners      │            │   │
 │  │  │CopyOnWriteArrayList │  │ CopyOnWriteArrayList│            │   │
 │  │  │                     │  │                     │            │   │
-│  │  │  • CommandManager   │  │  • Model (logging)  │            │   │
-│  │  │  (automatización    │  │  • TerminalPresenter│            │   │
-│  │  │   del usuario)      │  │  • GraphicPresenter │            │   │
-│  │  │                     │  │  • Station          │            │   │
+ │  │  │  • CommandManager   │  │  • Model (logging)  │            │   │
+ │  │  │  (automatización    │  │  • TerminalPresenter│            │   │
+ │  │  │   del usuario)      │  │  • GraphicPresenter │            │   │
 │  │  └─────────────────────┘  └─────────────────────┘            │   │
 │  └──────────────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────────────┘
@@ -46,7 +45,7 @@ El `TrainEventDispatcher` es el núcleo de la gestión de eventos de cada tren. 
 | Categoría | Tipo de Lista | Propósito | Ejemplos |
 |---|---|---|---|
 | **Script** | `CopyOnWriteArrayList<TrainEventListener>` | Automatización definida por el usuario (vía ANTLR) | `CommandManager` |
-| **Core** | `CopyOnWriteArrayList<TrainEventListener>` | Componentes internos del sistema | `Model` (logging), `TerminalPresenter` (audio), `GraphicPresenter` (audio), `Station` |
+| **Core** | `CopyOnWriteArrayList<TrainEventListener>` | Componentes internos del sistema | `Model` (logging), `TerminalPresenter` (audio), `GraphicPresenter` (audio) |
 
 ### Ciclo de Vida del Dispatcher
 
@@ -256,14 +255,12 @@ public interface StationEventListener extends Serializable {
     default void onEndLoad(Train train) {}
     default void onStartUnload(Train train) {}
     default void onEndUnload(Train train) {}
-    default void onLink(Train train) {}
-    default void onUnlink(Train train) {}
 }
 ```
 
 **Registro**: `Station.addStationListener(StationEventListener)`
 
-**Nota**: `Station` también implementa `TrainEventListener` y se registra como **core listener** del tren cuando este entra, permitiéndole reaccionar a acoplamientos/desacoplamientos dentro de sus límites.
+`Station` recibe la visita de los trenes por herencia de `Sensor` (ver eventos de Sensor). No necesita registrarse como `TrainEventListener` para enterarse de cuándo un tren entra o sale, porque `TrainMovementManager` llama directamente a `sensorEnter.onEnterTrain(train)` sobre el objeto `Station`.
 
 ### Bifurcación (Fork)
 
@@ -315,23 +312,7 @@ public void addCoreTrainEventListener(TrainEventListener listener) {
 }
 ```
 
-### Estación (autoregistro dinámico)
 
-```java
-// Station.java — se registra como core listener cuando un tren entra
-@Override
-public void onEnterTrain(Train train, boolean isForward) {
-    // ...
-    train.addCoreTrainEventListener(this);  // se suscribe a eventos del tren
-    notifyEnterTrain(train, isForward);
-}
-
-@Override
-public void onExitTrain(Train train, boolean isForward) {
-    train.removeCoreTrainEventListener(this);  // se desuscribe al salir
-    notifyExitTrain(train, isForward);
-}
-```
 
 ### Sistema de Audio (TerminalPresenter)
 
@@ -439,9 +420,7 @@ sequenceDiagram
 │                 │ + onStartLoad   │                  │                  │
 │                 │ + onEndLoad     │                  │                  │
 │                 │ + onStartUnload │                  │                  │
-│                 │ + onEndUnload   │                  │                  │
-│                 │ + onLink        │                  │                  │
-│                 │ + onUnlink      │                  │                  │
+ │                 │ + onEndUnload   │                  │                  │
 └─────────────────┴─────────────────┴──────────────────┴──────────────────┘
 ```
 
@@ -460,11 +439,11 @@ PLANO 2: Eventos de Dispositivo de Vía (Sensor/Station/Fork/Semaphore)
   Emisor: Dispositivo de vía → su propia lista de listeners
   Propósito: Notificar eventos de tráfico en puntos específicos de la red
 
-PUENTE: Sensor implementa ambas interfaces
-  - Como TrainEventListener: recibe eventos de los trenes que lo atraviesan
-    (onSensorEnter desde el dispatcher del tren)
-  - Como emisor: notifica a sus propios SensorEventListener
+PUENTE: Sensor implementa SensorEventListener
+  - Como emisor (Sensor.onSensorEnter): notifica a sus propios SensorEventListener
     (otros dispositivos interesados en ese punto de la vía)
+  - El propio sensor se excluye de la notificación vía dispatcher
+    (if (l != sensor)) para evitar auto-recibirse
 ```
 
 ---

--- a/src/main/java/letrain/command/CommandManager.java
+++ b/src/main/java/letrain/command/CommandManager.java
@@ -145,20 +145,6 @@ public class CommandManager extends LeTrainProgramBaseVisitor<Object> {
                                 commands.forEach(c -> c.execute(train));
                             }
                         }
-
-                        @Override
-                        public void onLink(Train train) {
-                            if ("link".equals(event) && (filterTrainId == null || filterTrainId == train.getId())) {
-                                commands.forEach(c -> c.execute(train));
-                            }
-                        }
-
-                        @Override
-                        public void onUnlink(Train train) {
-                            if ("unlink".equals(event) && (filterTrainId == null || filterTrainId == train.getId())) {
-                                commands.forEach(c -> c.execute(train));
-                            }
-                        }
                     });
                 }
             }

--- a/src/main/java/letrain/itinerary/impl/AutoPilotImpl.java
+++ b/src/main/java/letrain/itinerary/impl/AutoPilotImpl.java
@@ -182,12 +182,21 @@ public class AutoPilotImpl implements AutoPilot {
     }
 
     private Segment getTrainCurrentSegment() {
-        if (train == null || train.getModel() == null) return null;
+        if (train == null || train.getModel() == null) {
+            return null;
+        }
+
         letrain.segments.RailwayGraph graph = train.getModel().getRailwayGraph();
-        if (graph == null) return null;
-        var first = train.getLinkers().isEmpty() ? null : train.getLinkers().getFirst();
-        if (first == null || first.getTrack() == null) return null;
-        letrain.track.Track t = first.getTrack();
+        if (graph == null){
+            return null;
+        }
+
+        var physicalFront = train.getPhysicalFront();
+        if (physicalFront == null || physicalFront.getTrack() == null) {
+            return null;
+        }
+
+        letrain.track.Track t = physicalFront.getTrack();
         return t instanceof letrain.track.rail.RailTrack ? graph.getSegment((letrain.track.rail.RailTrack) t) : null;
     }
 

--- a/src/main/java/letrain/mvp/impl/Model.java
+++ b/src/main/java/letrain/mvp/impl/Model.java
@@ -241,11 +241,6 @@ public class Model implements letrain.mvp.Model {
                 if (train != null) {
                     train.setModel(this);
                     train.postLoadInit();
-                    int stationId = train.getStationId();
-                    if (stationId != 0) {
-                        Station station = getStation(stationId);
-                        if (station != null) train.addCoreTrainEventListener(station);
-                    }
                     for (TrainEventListener l : scriptTrainEventListeners) {
                         train.addScriptTrainEventListener(l);
                     }
@@ -658,8 +653,6 @@ public class Model implements letrain.mvp.Model {
             @Override public void onExitTrain(Train train, boolean isForward) { eventLogManager.addEntry("Train " + train.getId() + " exited Station " + id); }
             @Override public void onLoad(Train train) {}
             @Override public void onUnload(Train train) {}
-            @Override public void onLink(Train train) { eventLogManager.addEntry("Train " + train.getId() + " linked at Station " + id); }
-            @Override public void onUnlink(Train train) { eventLogManager.addEntry("Train " + train.getId() + " unlinked at Station " + id); }
             @Override public void onStartLoad(Train train) { eventLogManager.addEntry("Train " + train.getId() + " starting Load at Station " + id); }
             @Override public void onEndLoad(Train train) { eventLogManager.addEntry("Train " + train.getId() + " ended Load at Station " + id); }
             @Override public void onStartUnload(Train train) { eventLogManager.addEntry("Train " + train.getId() + " starting Unload at Station " + id); }

--- a/src/main/java/letrain/mvp/impl/graphic/GraphicPresenter.java
+++ b/src/main/java/letrain/mvp/impl/graphic/GraphicPresenter.java
@@ -657,18 +657,6 @@ public class GraphicPresenter extends ApplicationAdapter
                 getRows());
 
 
-        // Re-attach stations as listeners to trains they are hosting
-        for (Locomotive loco : model.getLocomotives()) {
-            Train train = loco.getTrain();
-            if (train != null && train.getStationId() != 0) {
-                for (letrain.track.Station station : model.getStations()) {
-                    if (station.getId() == train.getStationId()) {
-                        train.addCoreTrainEventListener(station);
-                        break;
-                    }
-                }
-            }
-        }
     }
 
     @Override

--- a/src/main/java/letrain/track/Station.java
+++ b/src/main/java/letrain/track/Station.java
@@ -8,12 +8,11 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import letrain.utils.SerializationHelper;
 import letrain.vehicle.rail.impl.Train;
-import letrain.vehicle.rail.TrainEventListener;
 import letrain.visitor.Visitor;
 
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
 @com.fasterxml.jackson.annotation.JsonTypeName("Station")
-public class Station extends Sensor implements TrainEventListener {
+public class Station extends Sensor {
 
     private static final int BASE_MAX_STORAGE = 500;
     private static final int STORAGE_PER_INDUSTRY = 100;
@@ -128,32 +127,6 @@ public class Station extends Sensor implements TrainEventListener {
         }
     }
 
-    public void notifyLink(Train train) {
-        if (stationListeners != null) {
-            for (StationEventListener l : stationListeners) {
-                l.onLink(train);
-            }
-        }
-        if (systemStationListeners != null) {
-            for (StationEventListener l : systemStationListeners) {
-                l.onLink(train);
-            }
-        }
-    }
-
-    public void notifyUnlink(Train train) {
-        if (stationListeners != null) {
-            for (StationEventListener l : stationListeners) {
-                l.onUnlink(train);
-            }
-        }
-        if (systemStationListeners != null) {
-            for (StationEventListener l : systemStationListeners) {
-                l.onUnlink(train);
-            }
-        }
-    }
-
     public Station() {
     }
 
@@ -176,7 +149,6 @@ public class Station extends Sensor implements TrainEventListener {
     public void onSensorEnter(Train train, boolean isForward) {
         train.setStationId(getId());
         super.onSensorEnter(train, isForward);
-        train.addCoreTrainEventListener(this);
         notifyStationEvent(train, true, isForward);
     }
 
@@ -184,7 +156,6 @@ public class Station extends Sensor implements TrainEventListener {
     public void onSensorExit(Train train, boolean isForward) {
         super.onSensorExit(train, isForward);
         train.setStationId(0);
-        train.removeCoreTrainEventListener(this);
         notifyStationEvent(train, false, isForward);
     }
 
@@ -205,32 +176,6 @@ public class Station extends Sensor implements TrainEventListener {
                     l.onExitTrain(train, isForward);
             }
         }
-    }
-
-    @Override
-    public void onSpeedChanged(int speed) {
-    }
-
-    @Override
-    public void onSenseChanged(boolean forward) {
-    }
-
-    @Override
-    public void onLink(Train train) {
-        notifyLink(train);
-    }
-
-    @Override
-    public void onUnlink(Train train) {
-        notifyUnlink(train);
-    }
-
-    @Override
-    public void onCrash(Train train, letrain.map.Point pos, int speed) {
-    }
-
-    @Override
-    public void onContact(Train train, letrain.map.Point pos, int speed) {
     }
 
     @Override

--- a/src/main/java/letrain/track/StationEventListener.java
+++ b/src/main/java/letrain/track/StationEventListener.java
@@ -28,10 +28,4 @@ public interface StationEventListener extends Serializable {
 
     default public void onEndUnload(Train train) {
     }
-
-    default public void onLink(Train train) {
-    }
-
-    default public void onUnlink(Train train) {
-    }
 }

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -49,8 +49,7 @@ public class Train implements Renderable {
     private Tractor directorLinker;
 
     private transient letrain.mvp.Model model;
-    public transient List<TrainEventListener> scriptTrainListeners;
-    public transient List<TrainEventListener> coreTrainListeners;
+    private transient TrainEventDispatcher eventDispatcher;
 
     public transient letrain.vehicle.rail.TrainMovementManager movementManager;
     private transient letrain.vehicle.rail.TrainSafetyManager safetyManager;
@@ -70,8 +69,7 @@ public class Train implements Renderable {
     public Train(int id) {
         this.id = ValidationUtils.requirePositive(id, "train id");
         this.linkers = new LinkedList<>();
-        this.scriptTrainListeners = new CopyOnWriteArrayList<>();
-        this.coreTrainListeners = new CopyOnWriteArrayList<>();
+        this.eventDispatcher = new TrainEventDispatcher(this);
 
         this.trainCouplingManager = new letrain.vehicle.rail.impl.TrainCouplingManager();
         this.setLogisticsManager(new TrainLogisticsManager(this));
@@ -163,14 +161,11 @@ public class Train implements Renderable {
     }
 
     public List<TrainEventListener> getScriptTrainListeners() {
-        return this.scriptTrainListeners;
+        return this.eventDispatcher.getScriptTrainListeners();
     }
 
     public List<TrainEventListener> getCoreTrainListeners() {
-        if (this.coreTrainListeners == null) {
-            this.coreTrainListeners = new CopyOnWriteArrayList<>();
-        }
-        return this.coreTrainListeners;
+        return this.eventDispatcher.getCoreTrainListeners();
     }
 
     public Model getModel() {
@@ -182,35 +177,23 @@ public class Train implements Renderable {
     }
 
     public void addScriptTrainEventListener(TrainEventListener listener) {
-        if (scriptTrainListeners == null) {
-            scriptTrainListeners = new CopyOnWriteArrayList<>();
-        }
-        scriptTrainListeners.add(listener);
+        this.eventDispatcher.addScriptTrainEventListener(listener);
     }
 
     public void removeScriptTrainEventListener(TrainEventListener listener) {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.remove(listener);
-        }
+        this.eventDispatcher.removeScriptTrainEventListener(listener);
     }
 
     public void addCoreTrainEventListener(TrainEventListener listener) {
-        if (coreTrainListeners == null) {
-            coreTrainListeners = new CopyOnWriteArrayList<>();
-        }
-        coreTrainListeners.add(listener);
+        this.eventDispatcher.addCoreTrainEventListener(listener);
     }
 
     public void removeCoreTrainEventListener(TrainEventListener listener) {
-        if (coreTrainListeners != null) {
-            coreTrainListeners.remove(listener);
-        }
+        this.eventDispatcher.removeCoreTrainEventListener(listener);
     }
 
     public void removeAllScriptTrainEventListeners() {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.clear();
-        }
+        this.eventDispatcher.removeAllScriptTrainEventListeners();
     }
 
     public void notifySpeedChanged(int speed) {
@@ -225,47 +208,19 @@ public class Train implements Renderable {
                 }
             }
         }
-        if (scriptTrainListeners != null) {
-            for (TrainEventListener l : scriptTrainListeners) {
-                l.onSpeedChanged(speed);
-            }
-        }
-        if (coreTrainListeners != null) {
-            for (TrainEventListener l : coreTrainListeners) {
-                l.onSpeedChanged(speed);
-            }
-        }
+        this.eventDispatcher.notifySpeedChanged(speed);
     }
 
     public void notifySenseChanged(boolean forward) {
-        if (scriptTrainListeners != null) {
-            for (TrainEventListener trainEventListener : scriptTrainListeners) {
-                trainEventListener.onSenseChanged(forward);
-            }
-        }
-        if (coreTrainListeners != null) {
-            for (TrainEventListener trainEventListener : coreTrainListeners) {
-                trainEventListener.onSenseChanged(forward);
-            }
-        }
+        this.eventDispatcher.notifySenseChanged(forward);
     }
 
     public void notifyLink() {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.forEach(l -> l.onLink(this));
-        }
-        if (coreTrainListeners != null) {
-            coreTrainListeners.forEach(l -> l.onLink(this));
-        }
+        this.eventDispatcher.notifyLink();
     }
 
     public void notifyUnlink() {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.forEach(l -> l.onUnlink(this));
-        }
-        if (coreTrainListeners != null) {
-            coreTrainListeners.forEach(l -> l.onUnlink(this));
-        }
+        this.eventDispatcher.notifyUnlink();
     }
 
     public void notifyEnterSensor(letrain.track.Sensor sensor, boolean isForward) {
@@ -275,20 +230,7 @@ public class Train implements Renderable {
         }
         isNotifying = true;
         try {
-            if (scriptTrainListeners != null) {
-                scriptTrainListeners.forEach(l -> {
-                    if (l != sensor) {
-                        l.onSensorEnter(this, isForward);
-                    }
-                });
-            }
-            if (coreTrainListeners != null) {
-                coreTrainListeners.forEach(l -> {
-                    if (l != sensor) {
-                        l.onSensorEnter(this, isForward);
-                    }
-                });
-            }
+            this.eventDispatcher.notifyEnterSensor(sensor, isForward);
             this.actionManager.checkWaypointArrival();
             if (isAutoMode()) {
                 autopilot.onSegmentEntered(safetyManager.getCurrentSegment());
@@ -305,32 +247,14 @@ public class Train implements Renderable {
         }
         isNotifying = true;
         try {
-            if (scriptTrainListeners != null) {
-                scriptTrainListeners.forEach(l -> {
-                    if (l != sensor) {
-                        l.onSensorExit(this, isForward);
-                    }
-                });
-            }
-            if (coreTrainListeners != null) {
-                coreTrainListeners.forEach(l -> {
-                    if (l != sensor) {
-                        l.onSensorExit(this, isForward);
-                    }
-                });
-            }
+            this.eventDispatcher.notifyExitSensor(sensor, isForward);
         } finally {
             isNotifying = false;
         }
     }
 
     public void notifySegmentOccupied(letrain.segments.Segment segment) {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.forEach(l -> l.onSegmentOccupied(this, segment));
-        }
-        if (coreTrainListeners != null) {
-            coreTrainListeners.forEach(l -> l.onSegmentOccupied(this, segment));
-        }
+        this.eventDispatcher.notifySegmentOccupied(segment);
     }
 
     public int getId() {
@@ -361,8 +285,10 @@ public class Train implements Renderable {
      * Reinitializes transient fields after deserialization.
      */
     public void postLoadInit() {
-        this.scriptTrainListeners = SerializationHelper.ensureListInitializedConcurrent(scriptTrainListeners);
-        this.coreTrainListeners = SerializationHelper.ensureListInitializedConcurrent(coreTrainListeners);
+        if (this.eventDispatcher == null) {
+            this.eventDispatcher = new TrainEventDispatcher(this);
+        }
+        this.eventDispatcher.postLoadInit();
         this.isNotifying = false;
         this.trainCouplingManager = new letrain.vehicle.rail.impl.TrainCouplingManager();
         this.safetyManager = new letrain.vehicle.rail.impl.TrainSafetyManager(this);
@@ -510,16 +436,7 @@ public class Train implements Renderable {
             t.setCurrentSpeed(0);
             t.setTargetSpeed(0);
         });
-        if (scriptTrainListeners != null) {
-            for (TrainEventListener l : scriptTrainListeners) {
-                l.onContact(this, pos, speed);
-            }
-        }
-        if (coreTrainListeners != null) {
-            for (TrainEventListener l : coreTrainListeners) {
-                l.onContact(this, pos, speed);
-            }
-        }
+        this.eventDispatcher.notifyContact(pos, speed);
     }
 
     /**
@@ -530,16 +447,7 @@ public class Train implements Renderable {
      */
     public void notifyCrash(letrain.map.Point pos, int speed) {
         this.stalled = true;
-        if (scriptTrainListeners != null) {
-            for (TrainEventListener l : scriptTrainListeners) {
-                l.onCrash(this, pos, speed);
-            }
-        }
-        if (coreTrainListeners != null) {
-            for (TrainEventListener l : coreTrainListeners) {
-                l.onCrash(this, pos, speed);
-            }
-        }
+        this.eventDispatcher.notifyCrash(pos, speed);
     }
 
     /**

--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java
@@ -68,127 +68,79 @@ public class TrainEventDispatcher {
     }
 
     public void notifySpeedChanged(int speed) {
-        if (scriptTrainListeners != null) {
-            for (TrainEventListener l : scriptTrainListeners) {
-                l.onSpeedChanged(speed);
-            }
+        for (TrainEventListener l : scriptTrainListeners) {
+            l.onSpeedChanged(speed);
         }
-        if (coreTrainListeners != null) {
-            for (TrainEventListener l : coreTrainListeners) {
-                l.onSpeedChanged(speed);
-            }
+        for (TrainEventListener l : coreTrainListeners) {
+            l.onSpeedChanged(speed);
         }
     }
 
     public void notifySenseChanged(boolean forward) {
-        if (scriptTrainListeners != null) {
-            for (TrainEventListener l : scriptTrainListeners) {
-                l.onSenseChanged(forward);
-            }
+        for (TrainEventListener l : scriptTrainListeners) {
+            l.onSenseChanged(forward);
         }
-        if (coreTrainListeners != null) {
-            for (TrainEventListener l : coreTrainListeners) {
-                l.onSenseChanged(forward);
-            }
+        for (TrainEventListener l : coreTrainListeners) {
+            l.onSenseChanged(forward);
         }
     }
 
     public void notifyLink() {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.forEach(l -> {
-                l.onLink(train);
-            });
-        }
-        if (coreTrainListeners != null) {
-            coreTrainListeners.forEach(l -> {
-                l.onLink(train);
-            });
-        }
+        scriptTrainListeners.forEach(l -> l.onLink(train));
+        coreTrainListeners.forEach(l -> l.onLink(train));
     }
 
     public void notifyUnlink() {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.forEach(l -> {
-                l.onUnlink(train);
-            });
-        }
-        if (coreTrainListeners != null) {
-            coreTrainListeners.forEach(l -> {
-                l.onUnlink(train);
-            });
-        }
+        scriptTrainListeners.forEach(l -> l.onUnlink(train));
+        coreTrainListeners.forEach(l -> l.onUnlink(train));
     }
 
     public void notifyEnterSensor(Sensor sensor, boolean isForward) {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.forEach(l -> {
-                if (l != sensor) {
-                    l.onSensorEnter(train, isForward);
-                }
-            });
-        }
-        if (coreTrainListeners != null) {
-            coreTrainListeners.forEach(l -> {
-                if (l != sensor) {
-                    l.onSensorEnter(train, isForward);
-                }
-            });
-        }
+        scriptTrainListeners.forEach(l -> {
+            if (l != sensor) {
+                l.onSensorEnter(train, isForward);
+            }
+        });
+        coreTrainListeners.forEach(l -> {
+            if (l != sensor) {
+                l.onSensorEnter(train, isForward);
+            }
+        });
     }
 
     public void notifyExitSensor(Sensor sensor, boolean isForward) {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.forEach(l -> {
-                if (l != sensor) {
-                    l.onSensorExit(train, isForward);
-                }
-            });
-        }
-        if (coreTrainListeners != null) {
-            coreTrainListeners.forEach(l -> {
-                if (l != sensor) {
-                    l.onSensorExit(train, isForward);
-                }
-            });
-        }
+        scriptTrainListeners.forEach(l -> {
+            if (l != sensor) {
+                l.onSensorExit(train, isForward);
+            }
+        });
+        coreTrainListeners.forEach(l -> {
+            if (l != sensor) {
+                l.onSensorExit(train, isForward);
+            }
+        });
     }
 
     public void notifySegmentOccupied(Segment segment) {
-        if (scriptTrainListeners != null) {
-            scriptTrainListeners.forEach(l -> {
-                l.onSegmentOccupied(train, segment);
-            });
-        }
-        if (coreTrainListeners != null) {
-            coreTrainListeners.forEach(l -> {
-                l.onSegmentOccupied(train, segment);
-            });
-        }
+        scriptTrainListeners.forEach(l -> l.onSegmentOccupied(train, segment));
+        coreTrainListeners.forEach(l -> l.onSegmentOccupied(train, segment));
     }
 
     public void notifyContact(Point pos, int speed) {
-        if (scriptTrainListeners != null) {
-            for (TrainEventListener l : scriptTrainListeners) {
-                l.onContact(train, pos, speed);
-            }
+        for (TrainEventListener l : scriptTrainListeners) {
+            l.onContact(train, pos, speed);
         }
-        if (coreTrainListeners != null) {
-            for (TrainEventListener l : coreTrainListeners) {
-                l.onContact(train, pos, speed);
-            }
+        for (TrainEventListener l : coreTrainListeners) {
+            l.onContact(train, pos, speed);
         }
     }
 
     public void notifyCrash(Point pos, int speed) {
-        if (scriptTrainListeners != null) {
-            for (TrainEventListener l : scriptTrainListeners) {
-                l.onCrash(train, pos, speed);
-            }
+        for (TrainEventListener l : scriptTrainListeners) {
+            l.onCrash(train, pos, speed);
         }
-        if (coreTrainListeners != null) {
-            for (TrainEventListener l : coreTrainListeners) {
-                l.onCrash(train, pos, speed);
-            }
+        for (TrainEventListener l : coreTrainListeners) {
+            l.onCrash(train, pos, speed);
         }
     }
 }

--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java
@@ -1,0 +1,194 @@
+package letrain.vehicle.rail.impl;
+
+import letrain.vehicle.rail.TrainEventListener;
+import letrain.track.Sensor;
+import letrain.segments.Segment;
+import letrain.map.Point;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import letrain.utils.SerializationHelper;
+
+/**
+ * Manages event listener registrations and broadcasts train events.
+ */
+public class TrainEventDispatcher {
+    private final Train train;
+    private List<TrainEventListener> scriptTrainListeners;
+    private List<TrainEventListener> coreTrainListeners;
+
+    public TrainEventDispatcher(Train train) {
+        this.train = train;
+        this.scriptTrainListeners = new CopyOnWriteArrayList<>();
+        this.coreTrainListeners = new CopyOnWriteArrayList<>();
+    }
+
+    public List<TrainEventListener> getScriptTrainListeners() {
+        if (scriptTrainListeners == null) {
+            scriptTrainListeners = new CopyOnWriteArrayList<>();
+        }
+        return scriptTrainListeners;
+    }
+
+    public List<TrainEventListener> getCoreTrainListeners() {
+        if (coreTrainListeners == null) {
+            coreTrainListeners = new CopyOnWriteArrayList<>();
+        }
+        return coreTrainListeners;
+    }
+
+    public void addScriptTrainEventListener(TrainEventListener listener) {
+        getScriptTrainListeners().add(listener);
+    }
+
+    public void removeScriptTrainEventListener(TrainEventListener listener) {
+        if (scriptTrainListeners != null) {
+            scriptTrainListeners.remove(listener);
+        }
+    }
+
+    public void addCoreTrainEventListener(TrainEventListener listener) {
+        getCoreTrainListeners().add(listener);
+    }
+
+    public void removeCoreTrainEventListener(TrainEventListener listener) {
+        if (coreTrainListeners != null) {
+            coreTrainListeners.remove(listener);
+        }
+    }
+
+    public void removeAllScriptTrainEventListeners() {
+        if (scriptTrainListeners != null) {
+            scriptTrainListeners.clear();
+        }
+    }
+
+    public void postLoadInit() {
+        scriptTrainListeners = SerializationHelper.ensureListInitializedConcurrent(scriptTrainListeners);
+        coreTrainListeners = SerializationHelper.ensureListInitializedConcurrent(coreTrainListeners);
+    }
+
+    public void notifySpeedChanged(int speed) {
+        if (scriptTrainListeners != null) {
+            for (TrainEventListener l : scriptTrainListeners) {
+                l.onSpeedChanged(speed);
+            }
+        }
+        if (coreTrainListeners != null) {
+            for (TrainEventListener l : coreTrainListeners) {
+                l.onSpeedChanged(speed);
+            }
+        }
+    }
+
+    public void notifySenseChanged(boolean forward) {
+        if (scriptTrainListeners != null) {
+            for (TrainEventListener l : scriptTrainListeners) {
+                l.onSenseChanged(forward);
+            }
+        }
+        if (coreTrainListeners != null) {
+            for (TrainEventListener l : coreTrainListeners) {
+                l.onSenseChanged(forward);
+            }
+        }
+    }
+
+    public void notifyLink() {
+        if (scriptTrainListeners != null) {
+            scriptTrainListeners.forEach(l -> {
+                l.onLink(train);
+            });
+        }
+        if (coreTrainListeners != null) {
+            coreTrainListeners.forEach(l -> {
+                l.onLink(train);
+            });
+        }
+    }
+
+    public void notifyUnlink() {
+        if (scriptTrainListeners != null) {
+            scriptTrainListeners.forEach(l -> {
+                l.onUnlink(train);
+            });
+        }
+        if (coreTrainListeners != null) {
+            coreTrainListeners.forEach(l -> {
+                l.onUnlink(train);
+            });
+        }
+    }
+
+    public void notifyEnterSensor(Sensor sensor, boolean isForward) {
+        if (scriptTrainListeners != null) {
+            scriptTrainListeners.forEach(l -> {
+                if (l != sensor) {
+                    l.onSensorEnter(train, isForward);
+                }
+            });
+        }
+        if (coreTrainListeners != null) {
+            coreTrainListeners.forEach(l -> {
+                if (l != sensor) {
+                    l.onSensorEnter(train, isForward);
+                }
+            });
+        }
+    }
+
+    public void notifyExitSensor(Sensor sensor, boolean isForward) {
+        if (scriptTrainListeners != null) {
+            scriptTrainListeners.forEach(l -> {
+                if (l != sensor) {
+                    l.onSensorExit(train, isForward);
+                }
+            });
+        }
+        if (coreTrainListeners != null) {
+            coreTrainListeners.forEach(l -> {
+                if (l != sensor) {
+                    l.onSensorExit(train, isForward);
+                }
+            });
+        }
+    }
+
+    public void notifySegmentOccupied(Segment segment) {
+        if (scriptTrainListeners != null) {
+            scriptTrainListeners.forEach(l -> {
+                l.onSegmentOccupied(train, segment);
+            });
+        }
+        if (coreTrainListeners != null) {
+            coreTrainListeners.forEach(l -> {
+                l.onSegmentOccupied(train, segment);
+            });
+        }
+    }
+
+    public void notifyContact(Point pos, int speed) {
+        if (scriptTrainListeners != null) {
+            for (TrainEventListener l : scriptTrainListeners) {
+                l.onContact(train, pos, speed);
+            }
+        }
+        if (coreTrainListeners != null) {
+            for (TrainEventListener l : coreTrainListeners) {
+                l.onContact(train, pos, speed);
+            }
+        }
+    }
+
+    public void notifyCrash(Point pos, int speed) {
+        if (scriptTrainListeners != null) {
+            for (TrainEventListener l : scriptTrainListeners) {
+                l.onCrash(train, pos, speed);
+            }
+        }
+        if (coreTrainListeners != null) {
+            for (TrainEventListener l : coreTrainListeners) {
+                l.onCrash(train, pos, speed);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cambios

### TrainEventDispatcher
- Eliminados null-checks redundantes en notify methods (punto 1 de la review)
- Eliminada interfaz onLink/onUnlink de StationEventListener
- Station ya no implementa TrainEventListener ni hace autoregistro dinámico

### Docs
- docs/events/TrainEvents.md - documentación del sistema de eventos
- docs/events/TrainEvents-Review.md - puntos de mejora detectados

### Cleanup
- Eliminado re-registro de estaciones en post-load (Model.java, GraphicPresenter.java)
- Eliminados handlers onLink/onUnlink de CommandManager