### PR TITLE
fix: remove orphan guard l != sensor

### DIFF
--- a/src/main/java/letrain/track/Sensor.java
+++ b/src/main/java/letrain/track/Sensor.java
@@ -101,7 +101,7 @@ public class Sensor implements Renderable {
     }
 
     public void onSensorEnter(Train train, boolean isForward) {
-        train.notifyEnterSensor(this, isForward);
+        train.notifyEnterSensor(isForward);
         if (listeners != null) {
             for (SensorEventListener listener : listeners) {
                 listener.onEnterTrain(train, isForward);
@@ -119,7 +119,7 @@ public class Sensor implements Renderable {
     }
 
     public void onSensorExit(Train train, boolean isForward) {
-        train.notifyExitSensor(this, isForward);
+        train.notifyExitSensor(isForward);
         if (listeners != null) {
             for (SensorEventListener listener : listeners) {
                 listener.onExitTrain(train, isForward);

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -235,10 +235,9 @@ public class Train implements Renderable {
         guardNotify(() -> this.eventDispatcher.notifyUnlink());
     }
 
-    public void notifyEnterSensor(letrain.track.Sensor sensor, boolean isForward) {
-        ValidationUtils.requireNonNull(sensor, "sensor");
+    public void notifyEnterSensor(boolean isForward) {
         guardNotify(() -> {
-            this.eventDispatcher.notifyEnterSensor(sensor, isForward);
+            this.eventDispatcher.notifyEnterSensor(isForward);
             this.actionManager.checkWaypointArrival();
             if (isAutoMode()) {
                 autopilot.onSegmentEntered(safetyManager.getCurrentSegment());
@@ -246,9 +245,8 @@ public class Train implements Renderable {
         });
     }
 
-    public void notifyExitSensor(letrain.track.Sensor sensor, boolean isForward) {
-        ValidationUtils.requireNonNull(sensor, "sensor");
-        guardNotify(() -> this.eventDispatcher.notifyExitSensor(sensor, isForward));
+    public void notifyExitSensor(boolean isForward) {
+        guardNotify(() -> this.eventDispatcher.notifyExitSensor(isForward));
     }
 
     public void notifySegmentOccupied(letrain.segments.Segment segment) {

--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java
@@ -1,7 +1,6 @@
 package letrain.vehicle.rail.impl;
 
 import letrain.vehicle.rail.TrainEventListener;
-import letrain.track.Sensor;
 import letrain.segments.Segment;
 import letrain.map.Point;
 import java.util.Collections;
@@ -102,30 +101,14 @@ public class TrainEventDispatcher {
         coreTrainListeners.forEach(l -> l.onUnlink(train));
     }
 
-    public void notifyEnterSensor(Sensor sensor, boolean isForward) {
-        scriptTrainListeners.forEach(l -> {
-            if (l != sensor) {
-                l.onSensorEnter(train, isForward);
-            }
-        });
-        coreTrainListeners.forEach(l -> {
-            if (l != sensor) {
-                l.onSensorEnter(train, isForward);
-            }
-        });
+    public void notifyEnterSensor(boolean isForward) {
+        scriptTrainListeners.forEach(l -> l.onSensorEnter(train, isForward));
+        coreTrainListeners.forEach(l -> l.onSensorEnter(train, isForward));
     }
 
-    public void notifyExitSensor(Sensor sensor, boolean isForward) {
-        scriptTrainListeners.forEach(l -> {
-            if (l != sensor) {
-                l.onSensorExit(train, isForward);
-            }
-        });
-        coreTrainListeners.forEach(l -> {
-            if (l != sensor) {
-                l.onSensorExit(train, isForward);
-            }
-        });
+    public void notifyExitSensor(boolean isForward) {
+        scriptTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
+        coreTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
     }
 
     public void notifySegmentOccupied(Segment segment) {


### PR DESCRIPTION
## Punto 4 de la review

La guarda `if (l != sensor)` evitaba que un Sensor registrado como TrainEventListener se auto-notificara. Desde que se eliminó `Station implements TrainEventListener`, ningún Sensor está en las listas de listeners — la guarda era código muerto.

### Cambios
- Eliminada guarda `if (l != sensor)` de `notifyEnterSensor` y `notifyExitSensor`
- Eliminado parámetro `Sensor sensor` (solo se usaba para la guarda)
- Simplificadas las firmas en Train.java y Sensor.java
- Eliminado import no usado de Sensor en el dispatcher