### PR TITLE
fix: remove dead SegmentOccupied event chain

### DIFF
--- a/src/main/java/letrain/itinerary/TrainActionManager.java
+++ b/src/main/java/letrain/itinerary/TrainActionManager.java
@@ -17,9 +17,6 @@ public interface TrainActionManager {
     void ensureForkRoute(letrain.segments.Segment from, letrain.segments.Segment to);
 
     /** Notify that a segment is occupied. */
-    void notifySegmentOccupied(letrain.segments.Segment segment);
-
-    /** Force a segment entry reset in safety manager. */
     void forceSegmentReset();
 
     /** Schedule the autopilot to resume after ticks. */

--- a/src/main/java/letrain/itinerary/impl/TrainActionManager.java
+++ b/src/main/java/letrain/itinerary/impl/TrainActionManager.java
@@ -139,11 +139,6 @@ public class TrainActionManager implements letrain.itinerary.TrainActionManager 
     }
 
     @Override
-    public void notifySegmentOccupied(Segment segment) {
-        this.train.notifySegmentOccupied(segment);
-    }
-
-    @Override
     public void forceSegmentReset() {
         //TODO: qué hacer aquí?
     }

--- a/src/main/java/letrain/vehicle/rail/TrainEventListener.java
+++ b/src/main/java/letrain/vehicle/rail/TrainEventListener.java
@@ -29,6 +29,4 @@ public interface TrainEventListener extends Serializable {
     default public void onSensorExit(Train train, boolean isForward) {
     }
 
-    default public void onSegmentOccupied(Train train, letrain.segments.Segment segment) {
-    }
 }

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -249,10 +249,6 @@ public class Train implements Renderable {
         guardNotify(() -> this.eventDispatcher.notifyExitSensor(isForward));
     }
 
-    public void notifySegmentOccupied(letrain.segments.Segment segment) {
-        guardNotify(() -> this.eventDispatcher.notifySegmentOccupied(segment));
-    }
-
     public int getId() {
         return this.id;
     }

--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcher.java
@@ -1,7 +1,6 @@
 package letrain.vehicle.rail.impl;
 
 import letrain.vehicle.rail.TrainEventListener;
-import letrain.segments.Segment;
 import letrain.map.Point;
 import java.util.Collections;
 import java.util.List;
@@ -109,11 +108,6 @@ public class TrainEventDispatcher {
     public void notifyExitSensor(boolean isForward) {
         scriptTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
         coreTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
-    }
-
-    public void notifySegmentOccupied(Segment segment) {
-        scriptTrainListeners.forEach(l -> l.onSegmentOccupied(train, segment));
-        coreTrainListeners.forEach(l -> l.onSegmentOccupied(train, segment));
     }
 
     public void notifyContact(Point pos, int speed) {


### PR DESCRIPTION
## Punto 5 de la review

`notifySegmentOccupied` en `TrainActionManager` nunca era llamado desde ningún sitio. Toda la cadena era código muerto.

### Eliminado
- `onSegmentOccupied` de `TrainEventListener`
- `notifySegmentOccupied` de `TrainEventDispatcher`
- `notifySegmentOccupied` de `Train`
- `notifySegmentOccupied` de `TrainActionManager` (interfaz e impl)
- Import no usado de `Segment` en el dispatcher

5 archivos, 20 líneas eliminadas.