### PR TITLE
feat: extract TrainEventDispatcher interface

### DIFF
--- a/src/main/java/letrain/vehicle/rail/TrainEventDispatcher.java
+++ b/src/main/java/letrain/vehicle/rail/TrainEventDispatcher.java
@@ -1,0 +1,41 @@
+package letrain.vehicle.rail;
+
+import letrain.map.Point;
+
+/**
+ * Manages event listener registrations and broadcasts train events.
+ */
+public interface TrainEventDispatcher {
+
+    java.util.List<TrainEventListener> getScriptTrainListeners();
+
+    java.util.List<TrainEventListener> getCoreTrainListeners();
+
+    void addScriptTrainEventListener(TrainEventListener listener);
+
+    void removeScriptTrainEventListener(TrainEventListener listener);
+
+    void addCoreTrainEventListener(TrainEventListener listener);
+
+    void removeCoreTrainEventListener(TrainEventListener listener);
+
+    void removeAllScriptTrainEventListeners();
+
+    void postLoadInit();
+
+    void notifySpeedChanged(int speed);
+
+    void notifySenseChanged(boolean forward);
+
+    void notifyLink();
+
+    void notifyUnlink();
+
+    void notifyEnterSensor(boolean isForward);
+
+    void notifyExitSensor(boolean isForward);
+
+    void notifyContact(Point pos, int speed);
+
+    void notifyCrash(Point pos, int speed);
+}

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -5,6 +5,7 @@ import letrain.utils.SerializationHelper;
 import letrain.utils.ValidationUtils;
 import letrain.vehicle.Tractor;
 import letrain.vehicle.rail.Linker;
+import letrain.vehicle.rail.TrainEventDispatcher;
 import letrain.vehicle.rail.TrainEventListener;
 import letrain.vehicle.rail.TrainMovementManager;
 import letrain.vehicle.rail.TrainSafetyManager;
@@ -69,7 +70,7 @@ public class Train implements Renderable {
     public Train(int id) {
         this.id = ValidationUtils.requirePositive(id, "train id");
         this.linkers = new LinkedList<>();
-        this.eventDispatcher = new TrainEventDispatcher(this);
+        this.eventDispatcher = new TrainEventDispatcherImpl(this);
 
         this.trainCouplingManager = new letrain.vehicle.rail.impl.TrainCouplingManager();
         this.setLogisticsManager(new TrainLogisticsManager(this));
@@ -278,7 +279,7 @@ public class Train implements Renderable {
      */
     public void postLoadInit() {
         if (this.eventDispatcher == null) {
-            this.eventDispatcher = new TrainEventDispatcher(this);
+        this.eventDispatcher = new TrainEventDispatcherImpl(this);
         }
         this.eventDispatcher.postLoadInit();
         this.isNotifying = false;

--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
@@ -1,5 +1,6 @@
 package letrain.vehicle.rail.impl;
 
+import letrain.vehicle.rail.TrainEventDispatcher;
 import letrain.vehicle.rail.TrainEventListener;
 import letrain.map.Point;
 import java.util.Collections;
@@ -10,12 +11,12 @@ import letrain.utils.SerializationHelper;
 /**
  * Manages event listener registrations and broadcasts train events.
  */
-public class TrainEventDispatcher {
+public class TrainEventDispatcherImpl implements TrainEventDispatcher {
     private final Train train;
     private List<TrainEventListener> scriptTrainListeners;
     private List<TrainEventListener> coreTrainListeners;
 
-    public TrainEventDispatcher(Train train) {
+    public TrainEventDispatcherImpl(Train train) {
         this.train = train;
         this.scriptTrainListeners = new CopyOnWriteArrayList<>();
         this.coreTrainListeners = new CopyOnWriteArrayList<>();

--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
@@ -22,6 +22,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         this.coreTrainListeners = new CopyOnWriteArrayList<>();
     }
 
+    @Override
     public List<TrainEventListener> getScriptTrainListeners() {
         if (scriptTrainListeners == null) {
             scriptTrainListeners = new CopyOnWriteArrayList<>();
@@ -29,6 +30,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         return Collections.unmodifiableList(scriptTrainListeners);
     }
 
+    @Override
     public List<TrainEventListener> getCoreTrainListeners() {
         if (coreTrainListeners == null) {
             coreTrainListeners = new CopyOnWriteArrayList<>();
@@ -36,6 +38,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         return Collections.unmodifiableList(coreTrainListeners);
     }
 
+    @Override
     public void addScriptTrainEventListener(TrainEventListener listener) {
         if (scriptTrainListeners == null) {
             scriptTrainListeners = new CopyOnWriteArrayList<>();
@@ -43,12 +46,14 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         scriptTrainListeners.add(listener);
     }
 
+    @Override
     public void removeScriptTrainEventListener(TrainEventListener listener) {
         if (scriptTrainListeners != null) {
             scriptTrainListeners.remove(listener);
         }
     }
 
+    @Override
     public void addCoreTrainEventListener(TrainEventListener listener) {
         if (coreTrainListeners == null) {
             coreTrainListeners = new CopyOnWriteArrayList<>();
@@ -56,23 +61,27 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         coreTrainListeners.add(listener);
     }
 
+    @Override
     public void removeCoreTrainEventListener(TrainEventListener listener) {
         if (coreTrainListeners != null) {
             coreTrainListeners.remove(listener);
         }
     }
 
+    @Override
     public void removeAllScriptTrainEventListeners() {
         if (scriptTrainListeners != null) {
             scriptTrainListeners.clear();
         }
     }
 
+    @Override
     public void postLoadInit() {
         scriptTrainListeners = SerializationHelper.ensureListInitializedConcurrent(scriptTrainListeners);
         coreTrainListeners = SerializationHelper.ensureListInitializedConcurrent(coreTrainListeners);
     }
 
+    @Override
     public void notifySpeedChanged(int speed) {
         for (TrainEventListener l : scriptTrainListeners) {
             l.onSpeedChanged(speed);
@@ -82,6 +91,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         }
     }
 
+    @Override
     public void notifySenseChanged(boolean forward) {
         for (TrainEventListener l : scriptTrainListeners) {
             l.onSenseChanged(forward);
@@ -91,26 +101,31 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         }
     }
 
+    @Override
     public void notifyLink() {
         scriptTrainListeners.forEach(l -> l.onLink(train));
         coreTrainListeners.forEach(l -> l.onLink(train));
     }
 
+    @Override
     public void notifyUnlink() {
         scriptTrainListeners.forEach(l -> l.onUnlink(train));
         coreTrainListeners.forEach(l -> l.onUnlink(train));
     }
 
+    @Override
     public void notifyEnterSensor(boolean isForward) {
         scriptTrainListeners.forEach(l -> l.onSensorEnter(train, isForward));
         coreTrainListeners.forEach(l -> l.onSensorEnter(train, isForward));
     }
 
+    @Override
     public void notifyExitSensor(boolean isForward) {
         scriptTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
         coreTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
     }
 
+    @Override
     public void notifyContact(Point pos, int speed) {
         for (TrainEventListener l : scriptTrainListeners) {
             l.onContact(train, pos, speed);
@@ -120,6 +135,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         }
     }
 
+    @Override
     public void notifyCrash(Point pos, int speed) {
         for (TrainEventListener l : scriptTrainListeners) {
             l.onCrash(train, pos, speed);


### PR DESCRIPTION
## Punto 6 de la review

El proyecto crea interfaces para casi todo, pero TrainEventDispatcher era una clase concreta sin interfaz.

### Cambios
- Creada interfaz `letrain.vehicle.rail.TrainEventDispatcher`
- Renombrado impl a `TrainEventDispatcherImpl`
- `Train.java` ahora usa la interfaz como tipo del campo
- Crea archivo nuevo + rename (git lo detecta como rename)