### PR TITLE
feat: TrainEventDispatcher interface + Core/Script listener split

### DIFF
--- a/src/main/java/letrain/command/CommandManager.java
+++ b/src/main/java/letrain/command/CommandManager.java
@@ -20,7 +20,7 @@ import letrain.track.Station;
 import letrain.track.StationEventListener;
 import letrain.track.rail.ForkRailTrack;
 import letrain.vehicle.Tractor;
-import letrain.vehicle.rail.TrainEventListener;
+import letrain.vehicle.rail.ScriptTrainEventListener;
 import letrain.vehicle.rail.impl.Locomotive;
 import letrain.vehicle.rail.impl.Train;
 import org.slf4j.Logger;
@@ -222,7 +222,7 @@ public class CommandManager extends LeTrainProgramBaseVisitor<Object> {
             if (ctx.trainEvent() != null) {
                 String event = ctx.trainEvent().getChild(0).getText();
                 String sense = ctx.trainEvent().sense() != null ? ctx.trainEvent().sense().getText() : null;
-                model.addScriptTrainEventListener(new TrainEventListener() {
+                model.addScriptTrainEventListener(new ScriptTrainEventListener() {
                     @Override
                     public void onSensorEnter(Train train, boolean isForward) {
                         boolean senseMatch = (sense == null) || (sense.equals("forward") && isForward)
@@ -259,7 +259,7 @@ public class CommandManager extends LeTrainProgramBaseVisitor<Object> {
                 });
             } else if (ctx.getChildCount() >= 3) {
                 String event = ctx.getChild(2).getText();
-                model.addScriptTrainEventListener(new TrainEventListener() {
+                model.addScriptTrainEventListener(new ScriptTrainEventListener() {
                     @Override
                     public void onCrash(Train train, letrain.map.Point pos, int speed) {
                         if ("crash".equals(event) && (filterTrainId == null || filterTrainId == train.getId())) {

--- a/src/main/java/letrain/mvp/Model.java
+++ b/src/main/java/letrain/mvp/Model.java
@@ -17,14 +17,15 @@ import letrain.track.rail.RailTrack;
 import letrain.vehicle.Cursor;
 import letrain.vehicle.rail.impl.Locomotive;
 import letrain.vehicle.rail.impl.Train;
-import letrain.vehicle.rail.TrainEventListener;
+import letrain.vehicle.rail.CoreTrainEventListener;
+import letrain.vehicle.rail.ScriptTrainEventListener;
 import letrain.vehicle.rail.impl.Wagon;
 
 public interface Model {
 
-    public void addScriptTrainEventListener(TrainEventListener listener);
+    public void addScriptTrainEventListener(ScriptTrainEventListener listener);
 
-    public void addCoreTrainEventListener(TrainEventListener listener);
+    public void addCoreTrainEventListener(CoreTrainEventListener listener);
 
     public void removeAllScriptTrainEventListeners();
 

--- a/src/main/java/letrain/mvp/impl/Model.java
+++ b/src/main/java/letrain/mvp/impl/Model.java
@@ -22,6 +22,8 @@ import letrain.track.Station;
 import letrain.track.rail.ForkRailTrack;
 import letrain.track.rail.RailTrack;
 import letrain.vehicle.Cursor;
+import letrain.vehicle.rail.CoreTrainEventListener;
+import letrain.vehicle.rail.ScriptTrainEventListener;
 import letrain.vehicle.rail.TrainEventListener;
 import letrain.vehicle.rail.impl.Train;
 import letrain.vehicle.rail.impl.Locomotive;
@@ -79,32 +81,29 @@ public class Model implements letrain.mvp.Model {
     int nextForkId;
     private transient CargoTypes selectedWagonType = CargoTypes.GOLD;
 
-    private transient List<TrainEventListener> scriptTrainEventListeners = new ArrayList<>();
-    private transient List<TrainEventListener> coreTrainEventListeners = new ArrayList<>();
+    private transient List<ScriptTrainEventListener> scriptTrainEventListeners = new ArrayList<>();
+    private transient List<CoreTrainEventListener> coreTrainEventListeners = new ArrayList<>();
 
     @Override
-    public void addScriptTrainEventListener(TrainEventListener listener) {
+    public void addScriptTrainEventListener(ScriptTrainEventListener listener) {
         if (this.scriptTrainEventListeners == null) {
             this.scriptTrainEventListeners = new ArrayList<>();
         }
         this.scriptTrainEventListeners.add(listener);
         for (Locomotive loco : locomotives) {
-            if (loco.getTrain() != null) {
+            if (loco.getTrain() != null)
                 loco.getTrain().addScriptTrainEventListener(listener);
-            }
         }
     }
 
-    @Override
-    public void addCoreTrainEventListener(TrainEventListener listener) {
+    public void addCoreTrainEventListener(CoreTrainEventListener listener) {
         if (this.coreTrainEventListeners == null) {
             this.coreTrainEventListeners = new ArrayList<>();
         }
         this.coreTrainEventListeners.add(listener);
         for (Locomotive loco : locomotives) {
-            if (loco.getTrain() != null) {
+            if (loco.getTrain() != null)
                 loco.getTrain().addCoreTrainEventListener(listener);
-            }
         }
     }
 
@@ -186,7 +185,7 @@ public class Model implements letrain.mvp.Model {
         this.stations = new ArrayList<>();
         this.map = new RailMap();
 
-        this.addCoreTrainEventListener(new TrainEventListener() {
+        this.addCoreTrainEventListener(new CoreTrainEventListener() {
             @Override public void onCrash(Train train, Point pos, int speed) {
                 eventLogManager.addEntry("CRASH! Train " + train.getId() + " crashed!");
                 getEconomyManager().onTrainCrashed(train);
@@ -241,10 +240,10 @@ public class Model implements letrain.mvp.Model {
                 if (train != null) {
                     train.setModel(this);
                     train.postLoadInit();
-                    for (TrainEventListener l : scriptTrainEventListeners) {
+                    for (ScriptTrainEventListener l : scriptTrainEventListeners) {
                         train.addScriptTrainEventListener(l);
                     }
-                    for (TrainEventListener l : coreTrainEventListeners) {
+                    for (CoreTrainEventListener l : coreTrainEventListeners) {
                         train.addCoreTrainEventListener(l);
                     }
                     train.getSafetyManager().claimOccupiedSegments();
@@ -263,7 +262,7 @@ public class Model implements letrain.mvp.Model {
     }
 
     private void setupModelTrainEventListeners() {
-        this.addCoreTrainEventListener(new TrainEventListener() {
+        this.addCoreTrainEventListener(new CoreTrainEventListener() {
             @Override public void onCrash(Train train, Point pos, int speed) {
                 eventLogManager.addEntry("CRASH! Train " + train.getId() + " crashed!");
                 getEconomyManager().onTrainCrashed(train);
@@ -420,10 +419,10 @@ public class Model implements letrain.mvp.Model {
         if (locomotive.getTrain() != null) {
             locomotive.getTrain().setModel(this);
             locomotive.getTrain().rebind();
-            for (TrainEventListener l : scriptTrainEventListeners) {
+            for (ScriptTrainEventListener l : scriptTrainEventListeners) {
                 locomotive.getTrain().addScriptTrainEventListener(l);
             }
-            for (TrainEventListener l : coreTrainEventListeners) {
+            for (CoreTrainEventListener l : coreTrainEventListeners) {
                 locomotive.getTrain().addCoreTrainEventListener(l);
             }
         }

--- a/src/main/java/letrain/mvp/impl/graphic/GraphicPresenter.java
+++ b/src/main/java/letrain/mvp/impl/graphic/GraphicPresenter.java
@@ -27,7 +27,7 @@ import letrain.mvp.impl.RailTrackMaker;
 import letrain.mvp.impl.SimulationController;
 import letrain.utils.FontManager;
 import letrain.utils.ValidationUtils;
-import letrain.vehicle.rail.TrainEventListener;
+import letrain.vehicle.rail.CoreTrainEventListener;
 import letrain.vehicle.rail.impl.Locomotive;
 import letrain.vehicle.rail.impl.Train;
 import letrain.visitor.gdx3d.Gdx3DRenderer;
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 public class GraphicPresenter extends ApplicationAdapter
         implements letrain.mvp.View, letrain.mvp.Presenter,
-        TrainEventListener {
+        CoreTrainEventListener {
     private static final Logger log = LoggerFactory.getLogger(GraphicPresenter.class);
     private static final String DEFAULT_SAVEGAME_FILENAME = "savegame.dat";
     private com.badlogic.gdx.graphics.PerspectiveCamera cam;

--- a/src/main/java/letrain/mvp/impl/terminal/TerminalPresenter.java
+++ b/src/main/java/letrain/mvp/impl/terminal/TerminalPresenter.java
@@ -32,7 +32,7 @@ import letrain.track.CargoTypes;
 import letrain.track.Station;
 import letrain.track.rail.RailTrack;
 import letrain.vehicle.rail.Linker;
-import letrain.vehicle.rail.TrainEventListener;
+import letrain.vehicle.rail.CoreTrainEventListener;
 import letrain.vehicle.rail.impl.Locomotive;
 import letrain.vehicle.rail.impl.Train;
 import letrain.vehicle.rail.impl.Wagon;
@@ -43,7 +43,7 @@ import org.antlr.v4.runtime.CharStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TerminalPresenter implements letrain.mvp.Presenter, TrainEventListener {
+public class TerminalPresenter implements letrain.mvp.Presenter, CoreTrainEventListener {
     Logger log = LoggerFactory.getLogger(TerminalPresenter.class);
 
     Model model;

--- a/src/main/java/letrain/vehicle/rail/CoreTrainEventListener.java
+++ b/src/main/java/letrain/vehicle/rail/CoreTrainEventListener.java
@@ -1,0 +1,6 @@
+package letrain.vehicle.rail;
+
+import java.io.Serializable;
+
+public interface CoreTrainEventListener extends TrainEventListener, Serializable {
+}

--- a/src/main/java/letrain/vehicle/rail/ScriptTrainEventListener.java
+++ b/src/main/java/letrain/vehicle/rail/ScriptTrainEventListener.java
@@ -1,0 +1,6 @@
+package letrain.vehicle.rail;
+
+import java.io.Serializable;
+
+public interface ScriptTrainEventListener extends TrainEventListener, Serializable {
+}

--- a/src/main/java/letrain/vehicle/rail/TrainEventDispatcher.java
+++ b/src/main/java/letrain/vehicle/rail/TrainEventDispatcher.java
@@ -1,0 +1,41 @@
+package letrain.vehicle.rail;
+
+import letrain.map.Point;
+
+/**
+ * Manages event listener registrations and broadcasts train events.
+ */
+public interface TrainEventDispatcher {
+
+    java.util.List<TrainEventListener> getScriptTrainListeners();
+
+    java.util.List<TrainEventListener> getCoreTrainListeners();
+
+    void addScriptTrainEventListener(TrainEventListener listener);
+
+    void removeScriptTrainEventListener(TrainEventListener listener);
+
+    void addCoreTrainEventListener(TrainEventListener listener);
+
+    void removeCoreTrainEventListener(TrainEventListener listener);
+
+    void removeAllScriptTrainEventListeners();
+
+    void postLoadInit();
+
+    void notifySpeedChanged(int speed);
+
+    void notifySenseChanged(boolean forward);
+
+    void notifyLink();
+
+    void notifyUnlink();
+
+    void notifyEnterSensor(boolean isForward);
+
+    void notifyExitSensor(boolean isForward);
+
+    void notifyContact(Point pos, int speed);
+
+    void notifyCrash(Point pos, int speed);
+}

--- a/src/main/java/letrain/vehicle/rail/TrainEventDispatcher.java
+++ b/src/main/java/letrain/vehicle/rail/TrainEventDispatcher.java
@@ -1,5 +1,7 @@
 package letrain.vehicle.rail;
 
+import java.util.List;
+
 import letrain.map.Point;
 
 /**
@@ -7,17 +9,17 @@ import letrain.map.Point;
  */
 public interface TrainEventDispatcher {
 
-    java.util.List<TrainEventListener> getScriptTrainListeners();
+    List<ScriptTrainEventListener> getScriptTrainListeners();
 
-    java.util.List<TrainEventListener> getCoreTrainListeners();
+    List<CoreTrainEventListener> getCoreTrainListeners();
 
-    void addScriptTrainEventListener(TrainEventListener listener);
+    void addScriptTrainEventListener(ScriptTrainEventListener listener);
 
-    void removeScriptTrainEventListener(TrainEventListener listener);
+    void removeScriptTrainEventListener(ScriptTrainEventListener listener);
 
-    void addCoreTrainEventListener(TrainEventListener listener);
+    void addCoreTrainEventListener(CoreTrainEventListener listener);
 
-    void removeCoreTrainEventListener(TrainEventListener listener);
+    void removeCoreTrainEventListener(CoreTrainEventListener listener);
 
     void removeAllScriptTrainEventListeners();
 

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -5,6 +5,7 @@ import letrain.utils.SerializationHelper;
 import letrain.utils.ValidationUtils;
 import letrain.vehicle.Tractor;
 import letrain.vehicle.rail.Linker;
+import letrain.vehicle.rail.TrainEventDispatcher;
 import letrain.vehicle.rail.TrainEventListener;
 import letrain.vehicle.rail.TrainMovementManager;
 import letrain.vehicle.rail.TrainSafetyManager;
@@ -69,7 +70,7 @@ public class Train implements Renderable {
     public Train(int id) {
         this.id = ValidationUtils.requirePositive(id, "train id");
         this.linkers = new LinkedList<>();
-        this.eventDispatcher = new TrainEventDispatcher(this);
+        this.eventDispatcher = new TrainEventDispatcherImpl(this);
 
         this.trainCouplingManager = new letrain.vehicle.rail.impl.TrainCouplingManager();
         this.setLogisticsManager(new TrainLogisticsManager(this));
@@ -278,7 +279,7 @@ public class Train implements Renderable {
      */
     public void postLoadInit() {
         if (this.eventDispatcher == null) {
-            this.eventDispatcher = new TrainEventDispatcher(this);
+        this.eventDispatcher = new TrainEventDispatcherImpl(this);
         }
         this.eventDispatcher.postLoadInit();
         this.isNotifying = false;

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -5,8 +5,9 @@ import letrain.utils.SerializationHelper;
 import letrain.utils.ValidationUtils;
 import letrain.vehicle.Tractor;
 import letrain.vehicle.rail.Linker;
+import letrain.vehicle.rail.CoreTrainEventListener;
+import letrain.vehicle.rail.ScriptTrainEventListener;
 import letrain.vehicle.rail.TrainEventDispatcher;
-import letrain.vehicle.rail.TrainEventListener;
 import letrain.vehicle.rail.TrainMovementManager;
 import letrain.vehicle.rail.TrainSafetyManager;
 import letrain.visitor.Renderable;
@@ -161,11 +162,11 @@ public class Train implements Renderable {
         this.model = model;
     }
 
-    public List<TrainEventListener> getScriptTrainListeners() {
+    public List<ScriptTrainEventListener> getScriptTrainListeners() {
         return this.eventDispatcher.getScriptTrainListeners();
     }
 
-    public List<TrainEventListener> getCoreTrainListeners() {
+    public List<CoreTrainEventListener> getCoreTrainListeners() {
         return this.eventDispatcher.getCoreTrainListeners();
     }
 
@@ -177,19 +178,19 @@ public class Train implements Renderable {
         return this.pendingReverse;
     }
 
-    public void addScriptTrainEventListener(TrainEventListener listener) {
+    public void addScriptTrainEventListener(ScriptTrainEventListener listener) {
         this.eventDispatcher.addScriptTrainEventListener(listener);
     }
 
-    public void removeScriptTrainEventListener(TrainEventListener listener) {
+    public void removeScriptTrainEventListener(ScriptTrainEventListener listener) {
         this.eventDispatcher.removeScriptTrainEventListener(listener);
     }
 
-    public void addCoreTrainEventListener(TrainEventListener listener) {
+    public void addCoreTrainEventListener(CoreTrainEventListener listener) {
         this.eventDispatcher.addCoreTrainEventListener(listener);
     }
 
-    public void removeCoreTrainEventListener(TrainEventListener listener) {
+    public void removeCoreTrainEventListener(CoreTrainEventListener listener) {
         this.eventDispatcher.removeCoreTrainEventListener(listener);
     }
 

--- a/src/main/java/letrain/vehicle/rail/impl/TrainCouplingManager.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainCouplingManager.java
@@ -11,9 +11,10 @@ import java.util.function.Supplier;
 
 import letrain.map.Dir;
 import letrain.track.Track;
+import letrain.vehicle.rail.CoreTrainEventListener;
 import letrain.vehicle.rail.Linker;
 import letrain.vehicle.rail.RailIterator;
-import letrain.vehicle.rail.TrainEventListener;
+import letrain.vehicle.rail.ScriptTrainEventListener;
 
 public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingManager {
 
@@ -300,10 +301,10 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
         if (toRemove > 0) {
             Train newTrain = new Train(nextTrainIdSupplier.get());
             newTrain.setModel(train.getModel());
-            for (TrainEventListener listener : train.getScriptTrainListeners()) {
+            for (ScriptTrainEventListener listener : train.getScriptTrainListeners()) {
                 newTrain.addScriptTrainEventListener(listener);
             }
-            for (TrainEventListener listener : train.getCoreTrainListeners()) {
+            for (CoreTrainEventListener listener : train.getCoreTrainListeners()) {
                 newTrain.addCoreTrainEventListener(listener);
             }
 
@@ -342,10 +343,10 @@ public class TrainCouplingManager implements letrain.vehicle.rail.TrainCouplingM
         if (train.getNumLinkersToRemove() > 0) {
             Train newTrain = new Train(nextTrainIdSupplier.get());
             newTrain.setModel(train.getModel());
-            for (TrainEventListener listener : train.getScriptTrainListeners()) {
+            for (ScriptTrainEventListener listener : train.getScriptTrainListeners()) {
                 newTrain.addScriptTrainEventListener(listener);
             }
-            for (TrainEventListener listener : train.getCoreTrainListeners()) {
+            for (CoreTrainEventListener listener : train.getCoreTrainListeners()) {
                 newTrain.addCoreTrainEventListener(listener);
             }
 

--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
@@ -1,5 +1,6 @@
 package letrain.vehicle.rail.impl;
 
+import letrain.vehicle.rail.TrainEventDispatcher;
 import letrain.vehicle.rail.TrainEventListener;
 import letrain.map.Point;
 import java.util.Collections;
@@ -10,12 +11,12 @@ import letrain.utils.SerializationHelper;
 /**
  * Manages event listener registrations and broadcasts train events.
  */
-public class TrainEventDispatcher {
+public class TrainEventDispatcherImpl implements TrainEventDispatcher {
     private final Train train;
     private List<TrainEventListener> scriptTrainListeners;
     private List<TrainEventListener> coreTrainListeners;
 
-    public TrainEventDispatcher(Train train) {
+    public TrainEventDispatcherImpl(Train train) {
         this.train = train;
         this.scriptTrainListeners = new CopyOnWriteArrayList<>();
         this.coreTrainListeners = new CopyOnWriteArrayList<>();

--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
@@ -1,20 +1,23 @@
 package letrain.vehicle.rail.impl;
 
-import letrain.vehicle.rail.TrainEventDispatcher;
-import letrain.vehicle.rail.TrainEventListener;
-import letrain.map.Point;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import letrain.map.Point;
 import letrain.utils.SerializationHelper;
+import letrain.vehicle.rail.CoreTrainEventListener;
+import letrain.vehicle.rail.ScriptTrainEventListener;
+import letrain.vehicle.rail.TrainEventDispatcher;
+import letrain.vehicle.rail.TrainEventListener;
 
 /**
  * Manages event listener registrations and broadcasts train events.
  */
 public class TrainEventDispatcherImpl implements TrainEventDispatcher {
     private final Train train;
-    private List<TrainEventListener> scriptTrainListeners;
-    private List<TrainEventListener> coreTrainListeners;
+    private List<ScriptTrainEventListener> scriptTrainListeners;
+    private List<CoreTrainEventListener> coreTrainListeners;
 
     public TrainEventDispatcherImpl(Train train) {
         this.train = train;
@@ -23,7 +26,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
     }
 
     @Override
-    public List<TrainEventListener> getScriptTrainListeners() {
+    public List<ScriptTrainEventListener> getScriptTrainListeners() {
         if (scriptTrainListeners == null) {
             scriptTrainListeners = new CopyOnWriteArrayList<>();
         }
@@ -31,7 +34,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
     }
 
     @Override
-    public List<TrainEventListener> getCoreTrainListeners() {
+    public List<CoreTrainEventListener> getCoreTrainListeners() {
         if (coreTrainListeners == null) {
             coreTrainListeners = new CopyOnWriteArrayList<>();
         }
@@ -39,7 +42,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
     }
 
     @Override
-    public void addScriptTrainEventListener(TrainEventListener listener) {
+    public void addScriptTrainEventListener(ScriptTrainEventListener listener) {
         if (scriptTrainListeners == null) {
             scriptTrainListeners = new CopyOnWriteArrayList<>();
         }
@@ -47,14 +50,14 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
     }
 
     @Override
-    public void removeScriptTrainEventListener(TrainEventListener listener) {
+    public void removeScriptTrainEventListener(ScriptTrainEventListener listener) {
         if (scriptTrainListeners != null) {
             scriptTrainListeners.remove(listener);
         }
     }
 
     @Override
-    public void addCoreTrainEventListener(TrainEventListener listener) {
+    public void addCoreTrainEventListener(CoreTrainEventListener listener) {
         if (coreTrainListeners == null) {
             coreTrainListeners = new CopyOnWriteArrayList<>();
         }
@@ -62,7 +65,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
     }
 
     @Override
-    public void removeCoreTrainEventListener(TrainEventListener listener) {
+    public void removeCoreTrainEventListener(CoreTrainEventListener listener) {
         if (coreTrainListeners != null) {
             coreTrainListeners.remove(listener);
         }

--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
@@ -22,6 +22,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         this.coreTrainListeners = new CopyOnWriteArrayList<>();
     }
 
+    @Override
     public List<TrainEventListener> getScriptTrainListeners() {
         if (scriptTrainListeners == null) {
             scriptTrainListeners = new CopyOnWriteArrayList<>();
@@ -29,6 +30,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         return Collections.unmodifiableList(scriptTrainListeners);
     }
 
+    @Override
     public List<TrainEventListener> getCoreTrainListeners() {
         if (coreTrainListeners == null) {
             coreTrainListeners = new CopyOnWriteArrayList<>();
@@ -36,6 +38,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         return Collections.unmodifiableList(coreTrainListeners);
     }
 
+    @Override
     public void addScriptTrainEventListener(TrainEventListener listener) {
         if (scriptTrainListeners == null) {
             scriptTrainListeners = new CopyOnWriteArrayList<>();
@@ -43,12 +46,14 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         scriptTrainListeners.add(listener);
     }
 
+    @Override
     public void removeScriptTrainEventListener(TrainEventListener listener) {
         if (scriptTrainListeners != null) {
             scriptTrainListeners.remove(listener);
         }
     }
 
+    @Override
     public void addCoreTrainEventListener(TrainEventListener listener) {
         if (coreTrainListeners == null) {
             coreTrainListeners = new CopyOnWriteArrayList<>();
@@ -56,23 +61,27 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         coreTrainListeners.add(listener);
     }
 
+    @Override
     public void removeCoreTrainEventListener(TrainEventListener listener) {
         if (coreTrainListeners != null) {
             coreTrainListeners.remove(listener);
         }
     }
 
+    @Override
     public void removeAllScriptTrainEventListeners() {
         if (scriptTrainListeners != null) {
             scriptTrainListeners.clear();
         }
     }
 
+    @Override
     public void postLoadInit() {
         scriptTrainListeners = SerializationHelper.ensureListInitializedConcurrent(scriptTrainListeners);
         coreTrainListeners = SerializationHelper.ensureListInitializedConcurrent(coreTrainListeners);
     }
 
+    @Override
     public void notifySpeedChanged(int speed) {
         for (TrainEventListener l : scriptTrainListeners) {
             l.onSpeedChanged(speed);
@@ -82,6 +91,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         }
     }
 
+    @Override
     public void notifySenseChanged(boolean forward) {
         for (TrainEventListener l : scriptTrainListeners) {
             l.onSenseChanged(forward);
@@ -91,26 +101,31 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         }
     }
 
+    @Override
     public void notifyLink() {
         scriptTrainListeners.forEach(l -> l.onLink(train));
         coreTrainListeners.forEach(l -> l.onLink(train));
     }
 
+    @Override
     public void notifyUnlink() {
         scriptTrainListeners.forEach(l -> l.onUnlink(train));
         coreTrainListeners.forEach(l -> l.onUnlink(train));
     }
 
+    @Override
     public void notifyEnterSensor(boolean isForward) {
         scriptTrainListeners.forEach(l -> l.onSensorEnter(train, isForward));
         coreTrainListeners.forEach(l -> l.onSensorEnter(train, isForward));
     }
 
+    @Override
     public void notifyExitSensor(boolean isForward) {
         scriptTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
         coreTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
     }
 
+    @Override
     public void notifyContact(Point pos, int speed) {
         for (TrainEventListener l : scriptTrainListeners) {
             l.onContact(train, pos, speed);
@@ -120,6 +135,7 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         }
     }
 
+    @Override
     public void notifyCrash(Point pos, int speed) {
         for (TrainEventListener l : scriptTrainListeners) {
             l.onCrash(train, pos, speed);

--- a/src/test/java/letrain/SerializationTest.java
+++ b/src/test/java/letrain/SerializationTest.java
@@ -16,7 +16,7 @@ import letrain.mvp.impl.Model;
 import letrain.track.Station;
 import letrain.track.rail.ForkRailTrack;
 import letrain.vehicle.rail.impl.*;
-import letrain.vehicle.rail.TrainEventListener;
+import letrain.vehicle.rail.ScriptTrainEventListener;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -123,7 +123,7 @@ class SerializationTest {
 
         // Add a listener
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
-        original.addScriptTrainEventListener(new TrainEventListener() {
+        original.addScriptTrainEventListener(new ScriptTrainEventListener() {
             @Override
             public void onSpeedChanged(int speed) {
                 listenerCalled.set(true);

--- a/src/test/java/letrain/vehicle/rail/rail2/TrainDeadEndCrashTest.java
+++ b/src/test/java/letrain/vehicle/rail/rail2/TrainDeadEndCrashTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import letrain.vehicle.rail.TrainEventListener;
+import letrain.vehicle.rail.ScriptTrainEventListener;
 import letrain.vehicle.rail.impl.Locomotive;
 import letrain.vehicle.rail.impl.Train;
 import org.junit.jupiter.api.DisplayName;
@@ -116,7 +116,7 @@ class TrainDeadEndCrashTest {
         train.setDirectorLinker(loco);
 
         // Add mock listener to verify notifyCrash
-        TrainEventListener listener = mock(TrainEventListener.class);
+        ScriptTrainEventListener listener = mock(ScriptTrainEventListener.class);
         train.addScriptTrainEventListener(listener);
 
         // --- Act ---
@@ -212,7 +212,7 @@ class TrainDeadEndCrashTest {
         train.setDirectorLinker(loco);
 
         // Listener to verify notifyContact (and absence of notifyCrash)
-        TrainEventListener listener = mock(TrainEventListener.class);
+        ScriptTrainEventListener listener = mock(ScriptTrainEventListener.class);
         train.addScriptTrainEventListener(listener);
 
         // --- Act ---
@@ -313,7 +313,7 @@ class TrainDeadEndCrashTest {
         train.getLinkers().add(linker);
 
         // Listener to verify no crash/contact is triggered
-        TrainEventListener listener = mock(TrainEventListener.class);
+        ScriptTrainEventListener listener = mock(ScriptTrainEventListener.class);
         train.addScriptTrainEventListener(listener);
 
         // --- Act ---
@@ -404,7 +404,7 @@ class TrainDeadEndCrashTest {
         train.getLinkers().add(loco);
         train.setDirectorLinker(loco);
 
-        TrainEventListener listener = mock(TrainEventListener.class);
+        ScriptTrainEventListener listener = mock(ScriptTrainEventListener.class);
         train.addScriptTrainEventListener(listener);
 
         // --- Act ---


### PR DESCRIPTION
## Puntos 6 y 7 de la review

### Punto 6: Interfaz para TrainEventDispatcher
- Creada `letrain.vehicle.rail.TrainEventDispatcher`
- Renombrado impl a `TrainEventDispatcherImpl`
- `Train.java` usa la interfaz como tipo

### Punto 7: Separación Core/Script listeners
- `CoreTrainEventListener extends TrainEventListener` (sistema)
- `ScriptTrainEventListener extends TrainEventListener` (automatización)
- `addCoreTrainEventListener` solo acepta `CoreTrainEventListener`
- `addScriptTrainEventListener` solo acepta `ScriptTrainEventListener`
- Error en compilación si mezclas, no en runtime

### Archivos modificados
13 archivos, interfaces nuevas: CoreTrainEventListener, ScriptTrainEventListener