### PR TITLE
refactor: extract notifyAll helper in TrainEventDispatcherImpl

### DIFF
--- a/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainEventDispatcherImpl.java
@@ -84,67 +84,48 @@ public class TrainEventDispatcherImpl implements TrainEventDispatcher {
         coreTrainListeners = SerializationHelper.ensureListInitializedConcurrent(coreTrainListeners);
     }
 
+    private void notifyAll(java.util.function.Consumer<TrainEventListener> notification) {
+        scriptTrainListeners.forEach(notification);
+        coreTrainListeners.forEach(notification);
+    }
+
     @Override
     public void notifySpeedChanged(int speed) {
-        for (TrainEventListener l : scriptTrainListeners) {
-            l.onSpeedChanged(speed);
-        }
-        for (TrainEventListener l : coreTrainListeners) {
-            l.onSpeedChanged(speed);
-        }
+        notifyAll(l -> l.onSpeedChanged(speed));
     }
 
     @Override
     public void notifySenseChanged(boolean forward) {
-        for (TrainEventListener l : scriptTrainListeners) {
-            l.onSenseChanged(forward);
-        }
-        for (TrainEventListener l : coreTrainListeners) {
-            l.onSenseChanged(forward);
-        }
+        notifyAll(l -> l.onSenseChanged(forward));
     }
 
     @Override
     public void notifyLink() {
-        scriptTrainListeners.forEach(l -> l.onLink(train));
-        coreTrainListeners.forEach(l -> l.onLink(train));
+        notifyAll(l -> l.onLink(train));
     }
 
     @Override
     public void notifyUnlink() {
-        scriptTrainListeners.forEach(l -> l.onUnlink(train));
-        coreTrainListeners.forEach(l -> l.onUnlink(train));
+        notifyAll(l -> l.onUnlink(train));
     }
 
     @Override
     public void notifyEnterSensor(boolean isForward) {
-        scriptTrainListeners.forEach(l -> l.onSensorEnter(train, isForward));
-        coreTrainListeners.forEach(l -> l.onSensorEnter(train, isForward));
+        notifyAll(l -> l.onSensorEnter(train, isForward));
     }
 
     @Override
     public void notifyExitSensor(boolean isForward) {
-        scriptTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
-        coreTrainListeners.forEach(l -> l.onSensorExit(train, isForward));
+        notifyAll(l -> l.onSensorExit(train, isForward));
     }
 
     @Override
     public void notifyContact(Point pos, int speed) {
-        for (TrainEventListener l : scriptTrainListeners) {
-            l.onContact(train, pos, speed);
-        }
-        for (TrainEventListener l : coreTrainListeners) {
-            l.onContact(train, pos, speed);
-        }
+        notifyAll(l -> l.onContact(train, pos, speed));
     }
 
     @Override
     public void notifyCrash(Point pos, int speed) {
-        for (TrainEventListener l : scriptTrainListeners) {
-            l.onCrash(train, pos, speed);
-        }
-        for (TrainEventListener l : coreTrainListeners) {
-            l.onCrash(train, pos, speed);
-        }
+        notifyAll(l -> l.onCrash(train, pos, speed));
     }
 }


### PR DESCRIPTION
## Punto 8 de la review

Los 9 métodos notify repetían exactamente el mismo patrón: iterar script listeners, iterar core listeners.

### Cambios
- Nuevo método privado `notifyAll(Consumer<TrainEventListener>)`
- Centraliza el orden de notificación (script → core) en un solo sitio
- 32 líneas eliminadas, 13 añadidas
- Cero cambio funcional