### PR TITLE
refactor: train handles its own emergency stop and crash destruction

### DIFF
--- a/src/main/java/letrain/vehicle/rail/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/rail/TrainMovementManager.java
@@ -24,6 +24,4 @@ public interface TrainMovementManager {
     void refreshLinkersDirection();
 
     void initiateBraking();
-
-    void restoreSpeed(int speed);
 }

--- a/src/main/java/letrain/vehicle/rail/TrainSafetyManager.java
+++ b/src/main/java/letrain/vehicle/rail/TrainSafetyManager.java
@@ -55,14 +55,6 @@ public interface TrainSafetyManager {
     void onEmergencyStop();
 
     /**
-     * Notificación cuando se inicia el frenado preventivo por bloque ocupado.
-     * Guarda la velocidad objetivo que tenía el tren antes de frenar.
-     *
-     * @param speedToSave velocidad objetivo previa al frenado.
-     */
-    void onBrakingInitiated(int speedToSave);
-
-    /**
      * Reclama y reserva todos los cantones físicamente ocupados por los vagones y locomotoras del tren.
      * Se utiliza típicamente en la inicialización o al cargar una partida.
      */

--- a/src/main/java/letrain/vehicle/rail/impl/Locomotive.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Locomotive.java
@@ -260,7 +260,7 @@ public class Locomotive extends Linker implements Tractor {
         if (getTrain() != null && getTrain().getSafetyManager() != null && getTrain().getSafetyManager().isWaitingForBlock()) {
             if (speed > 0) {
                 log.info("Locomotive {}: Train is waiting for block. Intercepting setTargetSpeed({}) and saving it instead.", id, speed);
-                getTrain().getSafetyManager().onBrakingInitiated(speed);
+                getTrain().setSavedTargetSpeed(speed);
                 speed = 0;
             }
         }

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -421,16 +421,41 @@ public class Train implements Renderable {
     }
 
     /**
+     * Stops all tractors immediately (speed = 0).
+     */
+    public void emergencyStop() {
+        getTractors().forEach(t -> {
+            t.setCurrentSpeed(0);
+            t.setTargetSpeed(0);
+        });
+    }
+
+    /**
+     * Destroys all linkers (speed = 0, force idle, destroy).
+     */
+    public void crashDestroy() {
+        setStalled(true);
+        getLinkers().forEach(l -> {
+            if (l instanceof Locomotive) {
+                ((Locomotive) l).setCurrentSpeed(0);
+                ((Locomotive) l).setTargetSpeed(0);
+                ((Locomotive) l).setForceIdleSound(true);
+            }
+            l.destroy();
+        });
+        if (getModel() != null) {
+            getModel().getBlockManager().releaseAll(this);
+        }
+    }
+
+    /**
      * Notifies listeners of a low-speed contact (speed &lt;
      * {@link #CRASH_SPEED_THRESHOLD}).
      * Stalls the train and sets all tractor speeds to 0.
      */
     public void notifyContact(letrain.map.Point pos, int speed) {
         guardNotify(() -> {
-            getTractors().forEach(t -> {
-                t.setCurrentSpeed(0);
-                t.setTargetSpeed(0);
-            });
+            emergencyStop();
             this.eventDispatcher.notifyContact(pos, speed);
         });
     }

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -431,10 +431,13 @@ public class Train implements Renderable {
     }
 
     /**
-     * Destroys all linkers (speed = 0, force idle, destroy).
+     * Notifies listeners of a crash and destroys all linkers.
      */
-    public void crashDestroy() {
-        setStalled(true);
+    public void crashDestroy(letrain.map.Point pos, int speed) {
+        guardNotify(() -> {
+            this.stalled = true;
+            this.eventDispatcher.notifyCrash(pos, speed);
+        });
         getLinkers().forEach(l -> {
             if (l instanceof Locomotive) {
                 ((Locomotive) l).setCurrentSpeed(0);

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -68,6 +68,11 @@ public class Train implements Renderable {
     public transient LinkersSense linkerDivisionSense;
     public transient boolean joined = false;
     private int savedSpeedBeforeReverse = -1;
+    private int savedTargetSpeed = -1;
+
+    public void setSavedTargetSpeed(int speed) {
+        this.savedTargetSpeed = speed;
+    }
 
     public Train(int id) {
         this.id = ValidationUtils.requirePositive(id, "train id");
@@ -421,11 +426,12 @@ public class Train implements Renderable {
     }
 
     /**
-     * Sets target speed to 0 on the director linker.
-     * The train will decelerate gradually (by inertia).
+     * Sets target speed to 0 on the director linker (gradual stop).
+     * Saves the current target speed so it can be restored later.
      */
     public void brake() {
         if (getDirectorLinker() != null) {
+            savedTargetSpeed = getDirectorLinker().getTargetSpeed();
             getDirectorLinker().setTargetSpeed(0);
         }
     }
@@ -434,10 +440,23 @@ public class Train implements Renderable {
      * Stops all tractors immediately (speed = 0).
      */
     public void emergencyStop() {
+        if (getDirectorLinker() != null) {
+            savedTargetSpeed = getDirectorLinker().getTargetSpeed();
+        }
         getTractors().forEach(t -> {
             t.setCurrentSpeed(0);
             t.setTargetSpeed(0);
         });
+    }
+
+    /**
+     * Restores the target speed saved before the last brake/emergencyStop.
+     */
+    public void restoreSpeed() {
+        if (savedTargetSpeed != -1 && getDirectorLinker() != null) {
+            getDirectorLinker().setTargetSpeed(savedTargetSpeed);
+            savedTargetSpeed = -1;
+        }
     }
 
     /**

--- a/src/main/java/letrain/vehicle/rail/impl/Train.java
+++ b/src/main/java/letrain/vehicle/rail/impl/Train.java
@@ -421,6 +421,16 @@ public class Train implements Renderable {
     }
 
     /**
+     * Sets target speed to 0 on the director linker.
+     * The train will decelerate gradually (by inertia).
+     */
+    public void brake() {
+        if (getDirectorLinker() != null) {
+            getDirectorLinker().setTargetSpeed(0);
+        }
+    }
+
+    /**
      * Stops all tractors immediately (speed = 0).
      */
     public void emergencyStop() {

--- a/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
@@ -207,15 +207,13 @@ public class TrainMovementManager implements letrain.vehicle.rail.TrainMovementM
         Point crashPos = linker.getPosition();
 
         if (!isAlreadyDestroying(train)) {
-            train.notifyCrash(crashPos, speed);
-            train.crashDestroy();
+            train.crashDestroy(crashPos, speed);
         }
 
         Train otherTrain = linker.getTrain();
         if (otherTrain != null) {
             if (!isAlreadyDestroying(otherTrain)) {
-                otherTrain.notifyCrash(crashPos, speed);
-                otherTrain.crashDestroy();
+                otherTrain.crashDestroy(crashPos, speed);
             }
         } else {
             log.info("crash: Destroying loose linker {} at crash position {}", linker, crashPos);

--- a/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
@@ -195,16 +195,9 @@ public class TrainMovementManager implements letrain.vehicle.rail.TrainMovementM
     private void contactDetected(Linker headOccupant, int speed) {
         Point collisionPos = headOccupant.getPosition();
         train.notifyContact(collisionPos, speed);
-        train.getTractors().forEach(t -> {
-            t.setCurrentSpeed(0);
-            t.setTargetSpeed(0);
-        });
         Train otherTrain = headOccupant.getTrain();
         if (otherTrain != null) {
-            otherTrain.getTractors().forEach(t -> {
-                t.setCurrentSpeed(0);
-                t.setTargetSpeed(0);
-            });
+            otherTrain.emergencyStop();
         }
     }
 
@@ -212,59 +205,31 @@ public class TrainMovementManager implements letrain.vehicle.rail.TrainMovementM
     @Override
     public void crashDetected(Linker linker, int speed) {
         Point crashPos = linker.getPosition();
-        boolean alreadyDestroying = false;
-        for (Linker l : train.getLinkers()) {
-            if (l instanceof Destructible && ((Destructible) l).isDestroying()) {
-                alreadyDestroying = true;
-                break;
-            }
-        }
 
-        if (!alreadyDestroying) {
+        if (!isAlreadyDestroying(train)) {
             train.notifyCrash(crashPos, speed);
-            train.getLinkers().forEach(l -> {
-                if (l instanceof Locomotive) {
-                    ((Locomotive) l).setCurrentSpeed(0);
-                    ((Locomotive) l).setTargetSpeed(0);
-                    ((Locomotive) l).setForceIdleSound(true);
-                }
-                l.destroy();
-            });
-            train.setStalled(true);
-            // Release segments so other trains can use them
-            if (train.getModel() != null) {
-                train.getModel().getBlockManager().releaseAll(train);
-            }
+            train.crashDestroy();
         }
 
-        // Also handle the other linker/train
-        if (linker.getTrain() != null) {
-            boolean otherAlreadyDestroying = false;
-            for (Linker l : linker.getTrain().getLinkers()) {
-                if (l instanceof Destructible && ((Destructible) l).isDestroying()) {
-                    otherAlreadyDestroying = true;
-                    break;
-                }
-            }
-            if (!otherAlreadyDestroying) {
-                linker.getTrain().notifyCrash(crashPos, speed);
-                linker.getTrain().getLinkers().forEach(l -> {
-                    if (l instanceof Locomotive) {
-                        ((Locomotive) l).setCurrentSpeed(0);
-                        ((Locomotive) l).setTargetSpeed(0);
-                        ((Locomotive) l).setForceIdleSound(true);
-                    }
-                    l.destroy();
-                });
-                linker.getTrain().setStalled(true);
-                if (linker.getTrain().getModel() != null) {
-                    linker.getTrain().getModel().getBlockManager().releaseAll(linker.getTrain());
-                }
+        Train otherTrain = linker.getTrain();
+        if (otherTrain != null) {
+            if (!isAlreadyDestroying(otherTrain)) {
+                otherTrain.notifyCrash(crashPos, speed);
+                otherTrain.crashDestroy();
             }
         } else {
             log.info("crash: Destroying loose linker {} at crash position {}", linker, crashPos);
             linker.destroy();
         }
+    }
+
+    private boolean isAlreadyDestroying(Train t) {
+        for (Linker l : t.getLinkers()) {
+            if (l instanceof Destructible && ((Destructible) l).isDestroying()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
@@ -264,9 +264,7 @@ public class TrainMovementManager implements letrain.vehicle.rail.TrainMovementM
     public void forceEmergencyStop() {
         if (train.isAutoMode()) {
             train.setAutoMode(false);
-            if (train.getDirectorLinker() != null) {
-                train.getDirectorLinker().setTargetSpeed(0);
-            }
+            train.brake();
             if (train.getSafetyManager() != null) {
                 train.getSafetyManager().onEmergencyStop();
             }

--- a/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
@@ -188,7 +188,6 @@ public class TrainMovementManager implements letrain.vehicle.rail.TrainMovementM
             lastLinker.setRailsSinceStop(lastLinker.getRailsSinceStop() + 1);
             lastLinkerNextTrack.setReservation(null);
         }
-
         return true;
     }
 
@@ -200,7 +199,6 @@ public class TrainMovementManager implements letrain.vehicle.rail.TrainMovementM
             otherTrain.emergencyStop();
         }
     }
-
 
     @Override
     public void crashDetected(Linker linker, int speed) {
@@ -285,18 +283,14 @@ public class TrainMovementManager implements letrain.vehicle.rail.TrainMovementM
 
         if (train.isStalled()) {
             Train.log.info("Train {} advance: cannot move because train is stalled", train.getId());
-            if (train.getDirectorLinker() != null) {
-                train.getDirectorLinker().setTargetSpeed(0);
-            }
+            train.brake();
             return false;
         }
 
         if (train.getModel() != null) {
             if (!train.getSafetyManager().hasPermissionToMove()) {
-                Train.log.info("Train {} advance: cannot move because hasPermissionToMove is false. Forcing setTargetSpeed(0)", train.getId());
-                if (train.getDirectorLinker() != null) {
-                    train.getDirectorLinker().setTargetSpeed(0);
-                }
+                Train.log.info("Train {} advance: cannot move because hasPermissionToMove is false. Forcing brake", train.getId());
+                train.brake();
                 return false;
             }
         }

--- a/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainMovementManager.java
@@ -422,21 +422,8 @@ public class TrainMovementManager implements letrain.vehicle.rail.TrainMovementM
 
     @Override
     public void initiateBraking() {
-        Tractor head = train.getDirectorLinker();
-        if (head != null) {
-            int currentTargetSpeed = head.getTargetSpeed();
-            Train.log.info("Train {} initiateBraking: target speed was {}, setting to 0", train.getId(), currentTargetSpeed);
-            train.getSafetyManager().onBrakingInitiated(currentTargetSpeed);
-            head.setTargetSpeed(0);
-        }
+        train.brake();
+        Train.log.info("Train {} initiateBraking: target speed set to 0", train.getId());
     }
 
-    @Override
-    public void restoreSpeed(int speed) {
-        Tractor head = train.getDirectorLinker();
-        if (head != null) {
-            Train.log.info("Train {} restoreSpeed: restoring target speed to {}", train.getId(), speed);
-            head.setTargetSpeed(speed);
-        }
-    }
 }

--- a/src/main/java/letrain/vehicle/rail/impl/TrainSafetyManager.java
+++ b/src/main/java/letrain/vehicle/rail/impl/TrainSafetyManager.java
@@ -29,7 +29,6 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
     private Segment nextSegment;
 
     private boolean isWaitingForBlock = false; // Única variable de estado de parada de bloque
-    private int savedTargetSpeed = -1;
     private transient boolean insideFindNextSegment = false;
 
     public TrainSafetyManager(Train train) {
@@ -80,18 +79,8 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
     }
 
     @Override
-    public void onBrakingInitiated(int speedToSave) {
-        log.info("Train {} onBrakingInitiated. Saved target speed: {}", train.getId(), savedTargetSpeed == -1 ? speedToSave : savedTargetSpeed);
-        this.isWaitingForBlock = true;
-        if (this.savedTargetSpeed == -1 && speedToSave > 0) {
-            this.savedTargetSpeed = speedToSave;
-        }
-    }
-
-    @Override
     public void onEmergencyStop() {
-        this.isWaitingForBlock = false; // Permitimos movimiento manual
-        this.savedTargetSpeed = -1;
+        this.isWaitingForBlock = false;
     }
 
     /**
@@ -141,8 +130,6 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
     public void acquireInitialLocks() {
         BlockManager bm = this.train.getModel().getBlockManager();
         RailwayGraph graph = this.train.getModel().getRailwayGraph();
-        savedTargetSpeed = -1;
-
         Linker head = train.getPhysicalFront();
         log.info("Train {} acquireInitialLocks starting", train.getId());
         if (head == null || head.getTrack() == null) {
@@ -269,7 +256,6 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
         log.info("Train {} onSegmentEntered: newSegment={}", train.getId(), newSegment != null ? newSegment.getId() : "null");
         currentSegment = newSegment;
         isWaitingForBlock = false;
-        savedTargetSpeed = -1;
 
 
 
@@ -358,11 +344,7 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
                 log.info("Train {} (AUTO) successfully woke up and locked segment  {}", train.getId(),
                         nextSegment.getId());
                 isWaitingForBlock = false;
-                if (savedTargetSpeed != -1) {
-                    train.movementManager.restoreSpeed(savedTargetSpeed);
-
-                    savedTargetSpeed = -1;
-                }
+                train.restoreSpeed();
             }
         }
     }
@@ -385,7 +367,6 @@ public class TrainSafetyManager implements letrain.vehicle.rail.TrainSafetyManag
 
         nextSegment = findNextSegment(head, graph);
         isWaitingForBlock = false;
-        savedTargetSpeed = -1;
 
         if (nextSegment == null || nextSegment.equals(currentSegment)) {
             isWaitingForBlock = false;


### PR DESCRIPTION
Closes #196

## Cambios

### Nuevos metodos en Train.java
- `emergencyStop()`: para todos los tractores (speed=0)
- `crashDestroy()`: destruye todos los linkers, libera bloques

### TrainMovementManager
- `contactDetected()`: ya no manipula tractores ajenos, llama a `otherTrain.emergencyStop()`
- `crashDetected()`: ya no manipula linkers ajenos, llama a `otherTrain.crashDestroy()`
- Extraido helper `isAlreadyDestroying()`